### PR TITLE
doc: remove `ray.init(address=)` from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ You can find sample TPU cluster manifests for [single-host](https://github.com/r
 
 For a quick-start guide to using TPUs with KubeRay, see [Use TPUs with KubeRay](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/tpu.html).
 
-
 ### Running Sample Workloads
 
 1. Save the following to a local file (e.g. `test_tpu.py`):
-```
+
+```python
 import ray
 
 ray.init(
-    address="ray://ray-cluster-kuberay-head-svc:10001",
     runtime_env={
         "pip": [
             "jax[tpu]",
@@ -76,8 +75,9 @@ num_workers = 4
 result = [tpu_cores.remote() for _ in range(num_workers)]
 print(ray.get(result))
 ```
-2. `kubectl port-forward svc/ray-cluster-kuberay-head-svc 8265:8265 &`
-3. `export RAY_ADDRESS=http://localhost:8265`
-4. `ray job submit --runtime-env-json='{"working_dir": "."}' -- python test_tpu.py`
+
+1. `kubectl port-forward svc/RAYCLUSTER-NAME-head-svc dashboard &` where `RAYCLUSTER-NAME` is the
+   `.metadata.name` of the RayCluster in the cluster manifest you used.
+1. `RAY_ADDRESS=http://localhost:8265 ray job submit --runtime-env-json='{"working_dir": "."}' -- python test_tpu.py`
 
 For a more advanced workload running Stable Diffusion on TPUs, see [here](https://cloud.google.com/kubernetes-engine/docs/add-on/ray-on-gke/tutorials/deploy-ray-serve-stable-diffusion-tpu). For an example of serving a LLM with TPUs, RayServe, and KubeRay, see [here](https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-lllm-tpu-ray).

--- a/samples/tpu-test.py
+++ b/samples/tpu-test.py
@@ -9,7 +9,6 @@ def tpu_cores():
 
 
 ray.init(
-    address="ray://ray-cluster-kuberay-head-svc:10001",
     runtime_env={
         "pip": [
             "jax[tpu]",


### PR DESCRIPTION
It's not necessary and currently doesn't work because the address doesn't match the linked RayCluster's K8s Service names.

* https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml
* https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.tpu-v4-multihost.yaml

Also fix the port-forward command's Service name.