### PR TITLE
fix: remove hardcoded jax[tpu] versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KubeRay with TPUs User Guide
 
-This page contains instructions for how to set up Ray on GKE with TPUs. 
+This page contains instructions for how to set up Ray on GKE with TPUs.
 
 
 ### Prerequisites
@@ -60,7 +60,7 @@ ray.init(
     address="ray://ray-cluster-kuberay-head-svc:10001",
     runtime_env={
         "pip": [
-            "jax[tpu]==0.4.12",
+            "jax[tpu]",
             "-f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
         ]
     }
@@ -79,5 +79,5 @@ print(ray.get(result))
 2. `kubectl port-forward svc/ray-cluster-kuberay-head-svc 8265:8265 &`
 3. `export RAY_ADDRESS=http://localhost:8265`
 4. `ray job submit --runtime-env-json='{"working_dir": "."}' -- python test_tpu.py`
-   
+
 For a more advanced workload running Stable Diffusion on TPUs, see [here](https://cloud.google.com/kubernetes-engine/docs/add-on/ray-on-gke/tutorials/deploy-ray-serve-stable-diffusion-tpu). For an example of serving a LLM with TPUs, RayServe, and KubeRay, see [here](https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-lllm-tpu-ray).

--- a/samples/tpu-test.py
+++ b/samples/tpu-test.py
@@ -6,13 +6,13 @@ def tpu_cores():
 
     print("TPU cores:" + str(jax.device_count()))
     return "TPU cores:" + str(jax.device_count())
-    
+
 
 ray.init(
     address="ray://ray-cluster-kuberay-head-svc:10001",
     runtime_env={
         "pip": [
-            "jax[tpu]==0.4.11",
+            "jax[tpu]",
             "-f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
             "ml_dtypes==0.2.0"
         ]


### PR DESCRIPTION
in examples. Otherwise they fail with errors like `TPU initialization failed: No ba16c7433 device found.`

Removing the version right now results in the installation of jax[tpu]==0.4.30.

contributes to #3