### PR TITLE
Avoid multi-slice scheduling deadlocks using Pod anti-affinity 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
+IMG ?= us-central1-docker.pkg.dev/ryanaoleary-gke-dev/kuberay-tpu-webhook/kuberay-tpu-webhook:latest
 
 # For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
   

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-central1-docker.pkg.dev/ryanaoleary-gke-dev/kuberay-tpu-webhook/kuberay-tpu-webhook:latest
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
 
 # For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
   

--- a/main.go
+++ b/main.go
@@ -343,7 +343,8 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 						clusterIn,
 					},
 				},
-				TopologyKey: topologyKey,
+				TopologyKey:       topologyKey,
+				NamespaceSelector: &metav1.LabelSelector{}, // Match all namespaces
 			},
 			{
 				LabelSelector: &metav1.LabelSelector{
@@ -352,7 +353,8 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 						replicaIndexExists,
 					},
 				},
-				TopologyKey: topologyKey,
+				TopologyKey:       topologyKey,
+				NamespaceSelector: &metav1.LabelSelector{}, // Match all namespaces
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -352,8 +352,16 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 						replicaIndexExists,
 					},
 				},
-				TopologyKey:       topologyKey,
-				NamespaceSelector: &metav1.LabelSelector{}, // Match all namespaces
+				TopologyKey: topologyKey,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "kubernetes.io/metadata.name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"kube-system"}, // match all except kube-system
+						},
+					},
+				},
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -343,8 +343,7 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 						clusterIn,
 					},
 				},
-				TopologyKey:       topologyKey,
-				NamespaceSelector: &metav1.LabelSelector{}, // Match all namespaces
+				TopologyKey: topologyKey,
 			},
 			{
 				LabelSelector: &metav1.LabelSelector{

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -959,6 +959,7 @@ func Test_InjectAffinity(t *testing.T) {
 			assert.Equal(t, []string{tc.expectedReplicaLabel}, term1MatchExprs["replicaIndex"].Values)
 			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs["ray.io/cluster"].Values)
+			assert.NotNil(t, podAntiAffinityTerms[0].NamespaceSelector)
 
 			// Check anti-affinity for Pods of different cluster when replicaIndex exists
 			term2MatchExprs := map[string]metav1.LabelSelectorRequirement{}
@@ -968,6 +969,7 @@ func Test_InjectAffinity(t *testing.T) {
 			assert.Equal(t, metav1.LabelSelectorOpExists, term2MatchExprs["replicaIndex"].Operator)
 			assert.Equal(t, metav1.LabelSelectorOpNotIn, term2MatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term2MatchExprs["ray.io/cluster"].Values)
+			assert.NotNil(t, podAntiAffinityTerms[1].NamespaceSelector)
 		})
 	}
 }
@@ -1544,7 +1546,8 @@ func Test_MutatePod(t *testing.T) {
 											},
 										},
 									},
-									"topologyKey": "cloud.google.com/gke-nodepool",
+									"topologyKey":       "cloud.google.com/gke-nodepool",
+									"namespaceSelector": map[string]interface{}{},
 								},
 								map[string]interface{}{
 									"labelSelector": map[string]interface{}{
@@ -1560,7 +1563,8 @@ func Test_MutatePod(t *testing.T) {
 											},
 										},
 									},
-									"topologyKey": "cloud.google.com/gke-nodepool",
+									"topologyKey":       "cloud.google.com/gke-nodepool",
+									"namespaceSelector": map[string]interface{}{},
 								},
 							},
 						},

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1545,7 +1545,7 @@ func Test_MutatePod(t *testing.T) {
 											},
 										},
 									},
-									"topologyKey":       "cloud.google.com/gke-nodepool",
+									"topologyKey": "cloud.google.com/gke-nodepool",
 								},
 								map[string]interface{}{
 									"labelSelector": map[string]interface{}{
@@ -1561,8 +1561,16 @@ func Test_MutatePod(t *testing.T) {
 											},
 										},
 									},
-									"topologyKey":       "cloud.google.com/gke-nodepool",
-									"namespaceSelector": map[string]interface{}{},
+									"topologyKey": "cloud.google.com/gke-nodepool",
+									"namespaceSelector": map[string]interface{}{
+										"matchExpressions": []interface{}{
+											map[string]interface{}{
+												"key":      "kubernetes.io/metadata.name",
+												"operator": "NotIn",
+												"values":   []interface{}{"kube-system"},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -959,7 +959,6 @@ func Test_InjectAffinity(t *testing.T) {
 			assert.Equal(t, []string{tc.expectedReplicaLabel}, term1MatchExprs["replicaIndex"].Values)
 			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs["ray.io/cluster"].Values)
-			assert.NotNil(t, podAntiAffinityTerms[0].NamespaceSelector)
 
 			// Check anti-affinity for Pods of different cluster when replicaIndex exists
 			term2MatchExprs := map[string]metav1.LabelSelectorRequirement{}
@@ -1547,7 +1546,6 @@ func Test_MutatePod(t *testing.T) {
 										},
 									},
 									"topologyKey":       "cloud.google.com/gke-nodepool",
-									"namespaceSelector": map[string]interface{}{},
 								},
 								map[string]interface{}{
 									"labelSelector": map[string]interface{}{


### PR DESCRIPTION
This PR adds the worker Pod's namespace and RayCluster name to the `replicaIndex` label that's injected to worker Pods and used for multi-host scheduling on GKE nodepools with an injected PodAffinity. Currently if multiple multi-host RayClusters are created in the same namespace with identical worker group names, multi-host replicas can be blocked from scheduling since more hosts than exist on the TPU slice will attempt to schedule together with affinity (i.e. a 4x4 slice from RayCluster A with `replicaIndex: tpu-group-0` will schedule, but if RayCluster B is created in the same namespace with a multi-host (of any topology) worker group named `tpu-group`, when replica `tpu-group-0` from B attempts to schedule it will be blocked due to the `podAffinity`.

We don't need to update `TPU_WORKER_HOSTNAMES` or the `hostname` field on each Pod (which previously was identical to the `replicaIndex`) since they are addressed through the RayCluster head service which is unique per namespace.