### PR TITLE
Update TPU webhook to v1.2.5-gke.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.0
 
 # For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
   

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -64,8 +64,8 @@ spec:
     spec:
       serviceAccountName: kuberay-tpu-webhook
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
-          imagePullPolicy: Always
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.0
+          imagePullPolicy: IfNotPresent
           name: kuberay-tpu-webhook
           args:
           - --v=0 # change this value to 1 for verbose logging

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.4"
+appVersion: "1.2.5"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -7,8 +7,8 @@ tpuWebhook:
   
   image:
     repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
-    tag: v1.2.3-gke.0
-    pullPolicy: Always
+    tag: v1.2.5-gke.0
+    pullPolicy: IfNotPresent
 
   deployment:
     replicas: 1


### PR DESCRIPTION
This PR updates the webhook image and helm chart to use the latest recommended version. `v1.2.5-gke.0` includes a bug-fix for scheduling deadlock with multi-host TPU slices and also updates the KubeRay dependency to import the `v1.4.0` version.