### PR TITLE
feat: Enhance templating options of chart

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -16,6 +16,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.tpuWebhook.namespace.name }}
+  labels:
+    {{- toYaml .Values.tpuWebhook.namespace.labels | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -63,26 +65,20 @@ spec:
         app:  kuberay-tpu-webhook
     spec:
       serviceAccountName: kuberay-tpu-webhook
+      securityContext:
+        {{- toYaml .Values.tpuWebhook.deployment.podSecurityContext | nindent 8 }}
       containers:
         - image: "{{ .Values.tpuWebhook.image.repository }}:{{ .Values.tpuWebhook.image.tag }}"
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-              add:
-              - "NET_BIND_SERVICE"
-            readOnlyRootFilesystem: true
-            runAsUser: 2007
-            seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml .Values.tpuWebhook.deployment.containerSecurityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.tpuWebhook.image.pullPolicy }}
           name: {{ .Chart.Name }}
           args:
           - --v={{ .Values.tpuWebhook.deployment.verbosity }}
+          - --bind-address=:{{ .Values.tpuWebhook.deployment.bindPort }}
           ports:
           - name: https
-            containerPort: 443
+            containerPort: {{ .Values.tpuWebhook.deployment.bindPort }}
             protocol: TCP
           livenessProbe:
             httpGet:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -4,6 +4,7 @@
 tpuWebhook:
   namespace:
     name: ray-system
+    labels: {}
   
   image:
     repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
@@ -13,6 +14,19 @@ tpuWebhook:
   deployment:
     replicas: 1
     verbosity: 0
+    bindPort: 443
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+        add:
+        - "NET_BIND_SERVICE"
+      readOnlyRootFilesystem: true
+      runAsUser: 2007
+      seccompProfile:
+        type: RuntimeDefault
+    podSecurityContext: {}
   
   service:
     type: ClusterIP


### PR DESCRIPTION
In order to comply with possible security constraints it might be necessary to have more templating options at hand.
So this PR is mainly about `podSecurityContext` and `containerSecurityContext`. Additionally by this it's possible to run webhook service on a non-privileged pod.



The program was tested solely for our own use cases, which might differ from yours.

<sub>Lucas Zanella [lucas.zanella@mercedes-benz.com](mailto:lucas.zanella@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>