### PR TITLE
Support Ironwood (v7x) TPU JAX intialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ const (
 	tpuProcessPortBase = 8471
 	megascalePortBase  = 8081
 	tpuResourceName    = corev1.ResourceName("google.com/tpu")
+	tpu7xType          = "tpu7x"
 )
 
 var (
@@ -751,7 +752,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 
 	// Detect v7x TPU accelerator
 	isV7x := false
-	if selector, ok := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]; ok && strings.HasPrefix(selector, "tpu7x") {
+	if selector, ok := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]; ok && strings.HasPrefix(selector, tpu7xType) {
 		isV7x = true
 	}
 
@@ -842,8 +843,8 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 			path := fmt.Sprintf("/spec/containers/%d/env", i)
 			isEnvInitialized := len(container.Env) > 0
 
-			// Legacy behavior is unique TPU_WORKER_ID per TPU Pod. With Ironwood
-			// TPU and newer, worker IDs are unique per container requesting TPU.
+			// For TPU generations up until v6e, TPU_WORKER_ID was indexed per TPU Pod.
+			// With Ironwood TPU and newer, worker IDs are unique per container requesting TPU.
 			finalWorkerID := tpuWorkerID
 			if isV7x {
 				finalWorkerID = (tpuWorkerID * numTpuContainers) + tpuContainerIndex

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ type TPUWebhookServer struct {
 type patch map[string]any
 
 const (
-	// TLS Certificate related constants.
+	// TLS certificate related constants.
 	certPath = "/etc/kuberay-tpu-webhook/tls/tls.crt"
 	keyPath  = "/etc/kuberay-tpu-webhook/tls/tls.key"
 
@@ -634,11 +634,9 @@ func (t *TPUWebhookServer) getSliceToTPUHosts(clusterName string, groupName stri
 
 			tpuWorkerIDEnvVar, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
 			if tpuWorkerIDEnvVar == "" {
-				if existingPod.Status.Phase == "Running" {
-					return nil, errors.New("existing TPU worker missing TPU_WORKER_ID")
-				}
-				// If the container has not yet been admitted, skip it.
-				continue
+				// If the container has been admitted without a TPU_WORKER_ID, return
+				// an error as this will cause the TPU slice to fail JAX initialization.
+				return nil, errors.New("existing TPU worker missing TPU_WORKER_ID")
 			}
 			foundWorkerID, err := strconv.Atoi(tpuWorkerIDEnvVar)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -192,27 +192,31 @@ func containerRequestingTPUs(containers ...corev1.Container) bool {
 	return false
 }
 
-// getNumTPUChipsRequested returns `google.com/TPU` Resource request value for the container
-// this indicates the number of TPU chips for the container to use
+// getNumTPUChipsRequested returns the total `google.com/TPU` Resource request value
+// summed across all containers. This indicates the total number of TPU chips the Pod requires.
 func getNumTPUChipsRequested(containers ...corev1.Container) int64 {
-	tpuLimit := int64(0)
-	tpuRequest := int64(0)
+	totalTPUs := int64(0)
 	for _, container := range containers {
-		if l := container.Resources.Limits; l != nil {
-			if resource := l[tpuResourceName]; !resource.IsZero() {
-				tpuLimit = resource.Value()
-			}
-		}
+		containerTPU := int64(0)
+		hasRequest := false
+
 		if r := container.Resources.Requests; r != nil {
 			if resource := r[tpuResourceName]; !resource.IsZero() {
-				tpuRequest = resource.Value()
+				containerTPU = resource.Value()
+				hasRequest = true
 			}
-		} else {
-			// default to limit if request is ommitted
-			tpuRequest = tpuLimit
 		}
+		if !hasRequest {
+			// default to limit if request is omitted
+			if l := container.Resources.Limits; l != nil {
+				if resource := l[tpuResourceName]; !resource.IsZero() {
+					containerTPU = resource.Value()
+				}
+			}
+		}
+		totalTPUs += containerTPU
 	}
-	return min(tpuLimit, tpuRequest)
+	return totalTPUs
 }
 
 // getNumTPUHostsFromTopology returns number of TPU VM hosts in Pod Slice specified by gke-tpu-topology Pod nodeSelector

--- a/main.go
+++ b/main.go
@@ -71,15 +71,18 @@ type TPUWebhookServer struct {
 // patch is a JSON patch describing mutate operation(s) for an incoming object.
 type patch map[string]any
 
-var (
-	certPath        = "/etc/kuberay-tpu-webhook/tls/tls.crt"
-	keyPath         = "/etc/kuberay-tpu-webhook/tls/tls.key"
-	tpuResourceName = corev1.ResourceName("google.com/tpu")
+const (
+	// TLS Certificate related constants.
+	certPath = "/etc/kuberay-tpu-webhook/tls/tls.crt"
+	keyPath  = "/etc/kuberay-tpu-webhook/tls/tls.key"
 
 	// TPU related constants.
 	tpuProcessPortBase = 8471
 	megascalePortBase  = 8081
+	tpuResourceName    = corev1.ResourceName("google.com/tpu")
+)
 
+var (
 	// Flag arguments.
 	BindAddr       string
 	KubeConfigPath string

--- a/main.go
+++ b/main.go
@@ -831,7 +831,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		container := containers[i]
 		if containerRequestingTPUs(container) {
 			path := fmt.Sprintf("/spec/containers/%d/env", i)
-			envArrayExists := len(container.Env) > 0
+			isEnvInitialized := len(container.Env) > 0
 
 			// Legacy behavior is unique TPU_WORKER_ID per TPU Pod. With Ironwood
 			// TPU and newer, worker IDs are unique per container requesting TPU.
@@ -846,10 +846,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 				// Multiple TPU multi-host replicas in the same worker group are assumed to be apart
 				// of a multi-slice configuration.
 				if val, _ := getEnvironmentVariable("MEGASCALE_SLICE_ID", container); val == "" {
-					patches, _ = addEnvVarPatch(patches, corev1.EnvVar{
+					patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{
 						Name:  "MEGASCALE_SLICE_ID",
 						Value: fmt.Sprint(replicaIndex),
-					}, path, envArrayExists || len(patches) > 0)
+					}, path, isEnvInitialized)
 				}
 
 				// Set MEGASCALE_COORDINATOR_ADDRESS, the address of worker 0 of slice 0.
@@ -859,10 +859,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 						// Target container 0's port
 						coordAddress = fmt.Sprintf("%s:%d", coordAddress, megascalePortBase)
 					}
-					patches, _ = addEnvVarPatch(patches, corev1.EnvVar{
+					patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{
 						Name:  "MEGASCALE_COORDINATOR_ADDRESS",
 						Value: coordAddress,
-					}, path, true)
+					}, path, isEnvInitialized)
 				}
 
 				// Set MEGASCALE_PORT, defaulting to 8081 since 8080 is used by Ray for metrics.
@@ -871,10 +871,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					megascalePort = fmt.Sprint(megascalePortBase + tpuContainerIndex)
 				}
 				if val, _ := getEnvironmentVariable("MEGASCALE_PORT", container); val == "" {
-					patches, _ = addEnvVarPatch(patches, corev1.EnvVar{
+					patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{
 						Name:  "MEGASCALE_PORT",
 						Value: megascalePort,
-					}, path, true)
+					}, path, isEnvInitialized)
 				}
 			}
 			// Network addressing injection logic.
@@ -895,11 +895,11 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 							return nil, err
 						}
 						klog.V(1).InfoS("mutatePod v7x", "RayCluster", namespace+"/"+clusterName, "TPU_PROCESS_ADDRESSES", processAddresses)
-						patches, _ = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_ADDRESSES", Value: processAddresses}, path, true)
+						patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_ADDRESSES", Value: processAddresses}, path, isEnvInitialized)
 					}
 
 					if val, _ := getEnvironmentVariable("TPU_PROCESS_PORT", container); val == "" {
-						patches, _ = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_PORT", Value: fmt.Sprint(tpuProcessPortBase + tpuContainerIndex)}, path, true)
+						patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_PORT", Value: fmt.Sprint(tpuProcessPortBase + tpuContainerIndex)}, path, isEnvInitialized)
 					}
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ var (
 	keyPath         = "/etc/kuberay-tpu-webhook/tls/tls.key"
 	tpuResourceName = corev1.ResourceName("google.com/tpu")
 
+	// TPU related constants.
+	tpuProcessPortBase = 8476
+	megascalePortBase  = 8081
+
 	// Flag arguments.
 	BindAddr       string
 	KubeConfigPath string
@@ -271,16 +275,32 @@ func genDNSHostnames(numOfHosts int32, groupName string, clusterName string, nam
 	return strings.Join(hostNames, ","), nil
 }
 
-// injectHostnames injects subdomain and TPU_WORKER_HOSTNAMES into a Pod for TPU multi-host initialization
+// getTPUProcessAdresses returns the list of process addresses (host:port) for all containers in the slice.
+// The base port is 8476. TPU_PROCESS_ADDRESSES replaces TPU_WORKER_HOSTNAMES for Ironwood (v7x) TPUs and newer.
+func getTPUProcessAdresses(numOfHosts int32, numTpuContainers int, groupName, clusterName string, replicaIndex int) (string, error) {
+	if numOfHosts == 0 {
+		return "", errors.New("workerGroupSpec NumOfHosts not set")
+	}
+	headlessServiceName := generateHeadlessServiceName(clusterName)
+	var addresses []string
+
+	for h := 0; h < int(numOfHosts); h++ {
+		hostName := fmt.Sprintf("%s-%d-%d.%s", groupName, replicaIndex, h, headlessServiceName)
+		for c := 0; c < numTpuContainers; c++ {
+			port := tpuProcessPortBase + c
+			addresses = append(addresses, fmt.Sprintf("%s:%d", hostName, port))
+		}
+	}
+	return strings.Join(addresses, ","), nil
+}
+
+// injectHostnames TPU_WORKER_HOSTNAMES into a Pod for multi-host initialization.
 func injectHostnames(clusterName string, hostNames string, envPath string, container corev1.Container, patches *[]patch) {
-	subdomainPatch, hostNamesPatch := patch{"op": "add"}, patch{"op": "add"}
-	subdomainPath := "/spec/subdomain"
+	hostNamesPatch := patch{"op": "add"}
 	tpuWorkerHostNames := corev1.EnvVar{
 		Name:  "TPU_WORKER_HOSTNAMES",
 		Value: hostNames,
 	}
-	subdomainPatch["path"] = subdomainPath
-	subdomainPatch["value"] = generateHeadlessServiceName(clusterName)
 	// create new EnvVar array if container.Env is empty, and append hostnames if not
 	if len(container.Env) == 0 {
 		hostNamesPatch["path"] = envPath
@@ -289,7 +309,17 @@ func injectHostnames(clusterName string, hostNames string, envPath string, conta
 		hostNamesPatch["path"] = fmt.Sprintf("%s/-", envPath)
 		hostNamesPatch["value"] = tpuWorkerHostNames
 	}
-	*patches = append(*patches, subdomainPatch, hostNamesPatch)
+	*patches = append(*patches, hostNamesPatch)
+}
+
+// injectSubdomain sets the Pod subdomain to match the headless service.
+func injectSubdomain(clusterName string, patches *[]patch) {
+	subdomainPatch := patch{
+		"op":    "add",
+		"path":  "/spec/subdomain",
+		"value": generateHeadlessServiceName(clusterName),
+	}
+	*patches = append(*patches, subdomainPatch)
 }
 
 // injectReplicaLabel injects replicaIndex label into a Pod for TPU Pod scheduling and Ray multi-host autoscaling
@@ -706,6 +736,22 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 	chipsPerHost := getNumTPUChipsRequested(containers...)
 	numOfHosts, _ := getNumTPUHostsFromTopology(clusterName, groupName, namespace, topology, chipsPerHost) // ignore error here because topology may not be set yet
 
+	// Detect v7x TPU accelerator
+	isV7x := false
+	if selector, ok := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]; ok && strings.HasPrefix(selector, "tpu7x") {
+		isV7x = true
+	}
+
+	// v7x (Ironwood) TPUs can run multiple NUMA-aligned containers per Pod to optimize
+	// memory bandwidth across the dual-chiplet architecture. We count them to assign
+	// unique worker IDs and network ports to each independent ML process.
+	numTpuContainers := 0
+	for _, c := range containers {
+		if containerRequestingTPUs(c) {
+			numTpuContainers++
+		}
+	}
+
 	// Pod indexing variables from K8s labels or assigned dynamically.
 	var replicaIndex int
 	var tpuWorkerID int
@@ -763,24 +809,32 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 	headlessServiceName := generateHeadlessServiceName(clusterName)
 
 	if numOfHosts > 1 {
-		// inject hostname into pod spec for DNS records
+		// inject hostname and subdomain into pod spec for DNS records
 		hostname := fmt.Sprintf("%s-%d-%d", groupName, replicaIndex, tpuWorkerID)
 		klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "hostname", hostname)
-		hostnamePatch := patch{"op": "add"}
-		hostnamePatch["path"] = "/spec/hostname"
-		hostnamePatch["value"] = hostname
+		hostnamePatch := patch{"op": "add", "path": "/spec/hostname", "value": hostname}
 		patches = append(patches, hostnamePatch)
+
+		injectSubdomain(clusterName, &patches)
 
 		// inject pod affinity/anti-affinity for scheduling
 		injectAffinity(pod, replicaIndex, groupName, &patches)
 	}
 
 	// inject all environment variables into the container requesting TPUs
+	tpuContainerIndex := 0
 	for i := 0; i < len(containers); i++ {
 		container := containers[i]
 		if containerRequestingTPUs(container) {
 			path := fmt.Sprintf("/spec/containers/%d/env", i)
 			envArrayExists := len(container.Env) > 0
+
+			// Legacy behavior is unique TPU_WORKER_ID per TPU Pod. With Ironwood
+			// TPU and newer, worker IDs are unique per container requesting TPU.
+			finalWorkerID := tpuWorkerID
+			if isV7x {
+				finalWorkerID = (tpuWorkerID * numTpuContainers) + tpuContainerIndex
+			}
 
 			// Multi-Slice variable injection logic.
 			if _, exists := getEnvironmentVariable("MEGASCALE_NUM_SLICES", container); exists {
@@ -797,6 +851,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 				// Set MEGASCALE_COORDINATOR_ADDRESS, the address of worker 0 of slice 0.
 				if val, _ := getEnvironmentVariable("MEGASCALE_COORDINATOR_ADDRESS", container); val == "" {
 					coordAddress := fmt.Sprintf("%s-0-0.%s", groupName, headlessServiceName)
+					if isV7x {
+						// Target container 0's port
+						coordAddress = fmt.Sprintf("%s:%d", coordAddress, megascalePortBase)
+					}
 					patches, _ = addEnvVarPatch(patches, corev1.EnvVar{
 						Name:  "MEGASCALE_COORDINATOR_ADDRESS",
 						Value: coordAddress,
@@ -804,30 +862,49 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 				}
 
 				// Set MEGASCALE_PORT, defaulting to 8081 since 8080 is used by Ray for metrics.
+				megascalePort := fmt.Sprint(megascalePortBase)
+				if isV7x {
+					megascalePort = fmt.Sprint(megascalePortBase + tpuContainerIndex)
+				}
 				if val, _ := getEnvironmentVariable("MEGASCALE_PORT", container); val == "" {
 					patches, _ = addEnvVarPatch(patches, corev1.EnvVar{
 						Name:  "MEGASCALE_PORT",
-						Value: "8081",
+						Value: megascalePort,
 					}, path, true)
 				}
 			}
-
+			// Network addressing injection logic.
 			if numOfHosts > 1 {
-				// inject TPU_WORKER_HOSTNAMES
-				hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
-				if err != nil {
-					return nil, err
+				if isV7x {
+					// v7x: Inject TPU_PROCESS_ADDRESSES & TPU_PROCESS_PORT
+					if val, _ := getEnvironmentVariable("TPU_PROCESS_ADDRESSES", container); val == "" {
+						processAddresses, err := getTPUProcessAdresses(numOfHosts, numTpuContainers, groupName, clusterName, replicaIndex)
+						if err != nil {
+							return nil, err
+						}
+						klog.V(1).InfoS("mutatePod v7x", "RayCluster", namespace+"/"+clusterName, "TPU_PROCESS_ADDRESSES", processAddresses)
+						patches, _ = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_ADDRESSES", Value: processAddresses}, path, true)
+					}
+
+					if val, _ := getEnvironmentVariable("TPU_PROCESS_PORT", container); val == "" {
+						patches, _ = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_PORT", Value: fmt.Sprint(tpuProcessPortBase + tpuContainerIndex)}, path, true)
+					}
+				} else {
+					// Legacy: inject TPU_WORKER_HOSTNAMES
+					hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
+					if err != nil {
+						return nil, err
+					}
+					klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
+					injectHostnames(clusterName, hostnames, path, container, &patches)
 				}
-				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
-				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "subdomain", generateHeadlessServiceName(clusterName))
-				injectHostnames(clusterName, hostnames, path, container, &patches)
 			}
 			// inject TPU_WORKER_ID
 			if value, _ := getEnvironmentVariable("TPU_WORKER_ID", container); value == "" {
-				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_ID", tpuWorkerID, "Replica Index", replicaIndex)
+				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_ID", finalWorkerID, "Replica Index", replicaIndex)
 				workerID := corev1.EnvVar{
 					Name:  "TPU_WORKER_ID",
-					Value: fmt.Sprint(tpuWorkerID),
+					Value: fmt.Sprint(finalWorkerID),
 				}
 				idPatch := patch{"op": "add"}
 				// create new EnvVar array if container.Env is empty, and append new EnvVars if not
@@ -902,6 +979,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 				}
 				patches = append(patches, pluginAddrPatch)
 			}
+			tpuContainerIndex++
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -165,12 +165,12 @@ func (t *TPUWebhookServer) Validate(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, string(responseBytes))
 }
 
-// printSliceToWorkerIds logs sliceToWorkerIDs contents for debugging
-func printSliceToWorkerIds(sliceToWorkerIDs map[slice][]int) {
-	for slice, workerList := range sliceToWorkerIDs {
-		klog.V(1).InfoS("printSliceToWorkerIds", "RayCluster", slice.namespace+"/"+slice.clusterName, "Worker Group", slice.groupName)
+// printsliceToTPUHosts logs sliceToTPUHosts contents for debugging
+func printsliceToTPUHosts(sliceToTPUHosts map[slice][]int) {
+	for slice, workerList := range sliceToTPUHosts {
+		klog.V(1).InfoS("printsliceToTPUHosts", "RayCluster", slice.namespace+"/"+slice.clusterName, "Worker Group", slice.groupName)
 		for _, workerID := range workerList {
-			klog.V(1).InfoS("printSliceToWorkerIds", "RayCluster", slice.namespace+"/"+slice.clusterName, "Worker ID", workerID)
+			klog.V(1).InfoS("printsliceToTPUHosts", "RayCluster", slice.namespace+"/"+slice.clusterName, "Worker ID", workerID)
 		}
 	}
 }
@@ -299,21 +299,17 @@ func getTPUProcessAdresses(numOfHosts int32, numTpuContainers int, groupName, cl
 }
 
 // injectHostnames TPU_WORKER_HOSTNAMES into a Pod for multi-host initialization.
-func injectHostnames(clusterName string, hostNames string, envPath string, container corev1.Container, patches *[]patch) {
-	hostNamesPatch := patch{"op": "add"}
+func injectHostnames(clusterName string, hostNames string, envPath string, container corev1.Container, patches *[]patch, envArrayExists bool) bool {
 	tpuWorkerHostNames := corev1.EnvVar{
 		Name:  "TPU_WORKER_HOSTNAMES",
 		Value: hostNames,
 	}
-	// create new EnvVar array if container.Env is empty, and append hostnames if not
-	if len(container.Env) == 0 {
-		hostNamesPatch["path"] = envPath
-		hostNamesPatch["value"] = []corev1.EnvVar{tpuWorkerHostNames}
-	} else {
-		hostNamesPatch["path"] = fmt.Sprintf("%s/-", envPath)
-		hostNamesPatch["value"] = tpuWorkerHostNames
-	}
-	*patches = append(*patches, hostNamesPatch)
+	// Append hostnames patch to the current list of patches.
+	var updatedPatches []patch
+	updatedPatches, envArrayExists = addEnvVarPatch(*patches, tpuWorkerHostNames, envPath, envArrayExists)
+	*patches = updatedPatches
+
+	return envArrayExists
 }
 
 // injectSubdomain sets the Pod subdomain to match the headless service.
@@ -519,23 +515,23 @@ func getEnvironmentVariable(varName string, container corev1.Container) (string,
 
 // getReplicaIndex returns the next lowest-index Pod Slice (worker group replica) to assign a Pod to in the RayCluster
 // there are three possible cases here:
-//  1. sliceToWorkerIDs is empty, this is the first pod the webhook intercepts
+//  1. sliceToTPUHosts is empty, this is the first pod the webhook intercepts
 //     - assign this pod to replica 0
-//  2. The Pod Slice exists in sliceToWorkerIDs, but has # created workers < NumOfHosts
+//  2. The Pod Slice exists in sliceToTPUHosts, but has # created workers < NumOfHosts
 //     - assign this pod to the lowest index replica with # created workers < NumOfHosts
 //     pods to the same replica
-//  3. sliceToWorkerIDs isn't empty, but all slices have # workers == NumOfHosts
+//  3. sliceToTPUHosts isn't empty, but all slices have # workers == NumOfHosts
 //     - this occurs when the pod we intercept is the first pod of a different slice in the cluster
-//     - we keep track of how many replicas of the same worker group have been added to sliceToWorkerIDs
+//     - we keep track of how many replicas of the same worker group have been added to sliceToTPUHosts
 //     so far, and assign this pod to the next integer replicaIndex
-func getReplicaIndex(sliceToWorkerIDs map[slice][]int, clusterName string, groupName string, namespace string) int {
+func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupName string, namespace string) int {
 	// first pod created in cluster
-	if len(sliceToWorkerIDs) == 0 {
+	if len(sliceToTPUHosts) == 0 {
 		return 0
 	}
 	nextLowestId := math.MaxInt32
 	numReplicas := 0 // tracks # of replicas in worker group created so far
-	for slice, workerList := range sliceToWorkerIDs {
+	for slice, workerList := range sliceToTPUHosts {
 		if slice.clusterName == clusterName && slice.groupName == groupName && slice.namespace == namespace {
 			numReplicas++
 			createdPods := len(workerList)
@@ -555,15 +551,15 @@ func getReplicaIndex(sliceToWorkerIDs map[slice][]int, clusterName string, group
 }
 
 // getNextWorkerID returns the next lowest TPU_WORKER_ID in the Pod Slice
-func getNextWorkerID(sliceToWorkerIDs map[slice][]int, podSlice slice, namespace string, replicaIndex int) (int, error) {
+func getNextWorkerID(sliceToTPUHosts map[slice][]int, podSlice slice, namespace string, replicaIndex int) (int, error) {
 	tpuWorkerID := 0 // defaults to 0 (first Pod in slice)
-	if len(sliceToWorkerIDs) == 0 || len(sliceToWorkerIDs[podSlice]) == 0 {
+	if len(sliceToTPUHosts) == 0 || len(sliceToTPUHosts[podSlice]) == 0 {
 		return tpuWorkerID, nil
 	}
-	sort.Ints(sliceToWorkerIDs[podSlice])
+	sort.Ints(sliceToTPUHosts[podSlice])
 	// iterate through existing workers and get the next lowest, unused ID
 	lastID := 0
-	for index, workerID := range sliceToWorkerIDs[podSlice] {
+	for index, workerID := range sliceToTPUHosts[podSlice] {
 		// check for incorrect assignment of IDs
 		if index == 0 {
 			lastID = workerID
@@ -581,9 +577,9 @@ func getNextWorkerID(sliceToWorkerIDs map[slice][]int, podSlice slice, namespace
 	return tpuWorkerID, nil
 }
 
-// getSliceToWorkerIDs returns a mapping representing the current RayCluster state of TPU pods using a PodLister
-func (t *TPUWebhookServer) getSliceToWorkerIDs(clusterName string, groupName string, namespace string, numOfHosts int32) (map[slice][]int, error) {
-	sliceToWorkerIDs := make(map[slice][]int)
+// getSliceToTPUHosts returns a mapping representing the current RayCluster state of TPU pods using a PodLister
+func (t *TPUWebhookServer) getSliceToTPUHosts(clusterName string, groupName string, namespace string, numOfHosts int32) (map[slice][]int, error) {
+	sliceToTPUHosts := make(map[slice][]int)
 
 	// we only care about workers in the same RayCluster and worker group when assigning IDs
 	podsInGroup, err := t.podLister.Pods(namespace).List(labels.SelectorFromSet(labels.Set{"ray.io/cluster": clusterName, "ray.io/group": groupName}))
@@ -593,9 +589,9 @@ func (t *TPUWebhookServer) getSliceToWorkerIDs(clusterName string, groupName str
 
 	if podsInGroup == nil {
 		// return an empty mapping if no Pods with 'ray.io/group' label found
-		return sliceToWorkerIDs, nil
+		return sliceToTPUHosts, nil
 	}
-	klog.V(1).InfoS("getSliceToWorkerIDs", "RayCluster", namespace+"/"+clusterName, "# Pods in Group", len(podsInGroup))
+	klog.V(1).InfoS("getSliceToTPUHosts", "RayCluster", namespace+"/"+clusterName, "# Pods in Group", len(podsInGroup))
 	for _, existingPod := range podsInGroup {
 		if existingPod.DeletionTimestamp != nil {
 			continue
@@ -608,7 +604,7 @@ func (t *TPUWebhookServer) getSliceToWorkerIDs(clusterName string, groupName str
 
 		if !containerRequestingTPUs(existingPod.Spec.Containers...) {
 			// Pod does not request TPUs, 'ray.io/group' is not a TPU worker group
-			return sliceToWorkerIDs, nil
+			return sliceToTPUHosts, nil
 		}
 		replicaIndexLabel := existingPod.Labels["replicaIndex"]
 		if replicaIndexLabel == "" {
@@ -617,37 +613,49 @@ func (t *TPUWebhookServer) getSliceToWorkerIDs(clusterName string, groupName str
 		}
 		replicaIndexLabelValues := strings.Split(replicaIndexLabel, "-")
 		existingReplicaIndex, _ := strconv.Atoi(replicaIndexLabelValues[len(replicaIndexLabelValues)-1])
-		existingWorkerID := -1
+
+		// Number of containers in this Pod to index.
+		numTpuContainers := 0
+		for _, c := range existingPod.Spec.Containers {
+			if containerRequestingTPUs(c) {
+				numTpuContainers++
+			}
+		}
+
+		podSlice := slice{clusterName, groupName, namespace, existingReplicaIndex, numOfHosts}
+		hostIndex := -1
 		for _, container := range existingPod.Spec.Containers {
 			if !containerRequestingTPUs(container) {
 				continue
 			}
 
 			tpuWorkerIDEnvVar, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
-			tempVar, err := strconv.Atoi(tpuWorkerIDEnvVar)
-			if err != nil {
-				klog.ErrorS(err, "getSliceToWorkerIDs", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_ID", tpuWorkerIDEnvVar)
+			if tpuWorkerIDEnvVar == "" {
+				if existingPod.Status.Phase == "Running" {
+					return nil, errors.New("existing TPU worker missing TPU_WORKER_ID")
+				}
+				// If the container has not yet been admitted, skip it.
 				continue
 			}
-			existingWorkerID = tempVar
+			foundWorkerID, err := strconv.Atoi(tpuWorkerIDEnvVar)
+			if err != nil {
+				klog.ErrorS(err, "getSliceToTPUHosts", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_ID", tpuWorkerIDEnvVar)
+				continue
+			}
+			// Determine the host this worker is running on.
+			hostIndex = foundWorkerID / numTpuContainers
 			break
 		}
-		if existingPod.Status.Phase == "Running" && existingWorkerID == -1 {
-			return nil, errors.New("existing TPU worker missing TPU_WORKER_ID")
-		}
-		if existingWorkerID != -1 {
-			// Pod has been intercepted by the webhook
-			podSlice := slice{clusterName, groupName, namespace, existingReplicaIndex, numOfHosts}
-			if sliceToWorkerIDs[podSlice] == nil {
-				sliceToWorkerIDs[podSlice] = []int{existingWorkerID}
+		if hostIndex != -1 {
+			if sliceToTPUHosts[podSlice] == nil {
+				sliceToTPUHosts[podSlice] = []int{hostIndex}
 			} else {
-				sliceToWorkerIDs[podSlice] = append(sliceToWorkerIDs[podSlice], existingWorkerID)
+				sliceToTPUHosts[podSlice] = append(sliceToTPUHosts[podSlice], hostIndex)
 			}
-			klog.V(1).InfoS("getSliceToWorkerIDs", "RayCluster", namespace+"/"+clusterName, "ReplicaIndex", existingReplicaIndex, "TPU_WORKER_ID", existingWorkerID)
-
+			klog.V(1).InfoS("getSliceToTPUHosts", "RayCluster", namespace+"/"+clusterName, "ReplicaIndex", existingReplicaIndex, "HostIndex", hostIndex)
 		}
 	}
-	return sliceToWorkerIDs, nil
+	return sliceToTPUHosts, nil
 }
 
 // extractPod returns a Pod unmarshalled from an Admission Request
@@ -790,15 +798,15 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		defer t.wg.Add(1)
 		t.waiting += 1
 
-		// query k8s client to populate sliceToWorkerIDs
-		sliceToWorkerIDs, err := t.getSliceToWorkerIDs(clusterName, groupName, namespace, numOfHosts)
+		// query k8s client to populate sliceToTPUHosts
+		sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
 		if err != nil {
 			return nil, err
 		}
 
-		replicaIndex = getReplicaIndex(sliceToWorkerIDs, clusterName, groupName, namespace)
+		replicaIndex = getReplicaIndex(sliceToTPUHosts, clusterName, groupName, namespace)
 		podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
-		tpuWorkerID, err = getNextWorkerID(sliceToWorkerIDs, podSlice, namespace, replicaIndex)
+		tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
 		if err != nil {
 			return nil, err
 		}
@@ -880,16 +888,22 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 			// Network addressing injection logic.
 			if numOfHosts > 1 {
 				// Legacy: inject TPU_WORKER_HOSTNAMES
-				hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
-				if err != nil {
-					return nil, err
+				val, _ := getEnvironmentVariable("TPU_WORKER_HOSTNAMES", container)
+				if val == "" || val == "localhost" {
+					// Inject value if unset or set to default value.
+					hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
+					if err != nil {
+						return nil, err
+					}
+					klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
+					isEnvInitialized = injectHostnames(clusterName, hostnames, path, container, &patches, isEnvInitialized)
 				}
-				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
-				injectHostnames(clusterName, hostnames, path, container, &patches)
 
 				if isV7x {
 					// v7x only: Inject TPU_PROCESS_ADDRESSES & TPU_PROCESS_PORT
-					if val, _ := getEnvironmentVariable("TPU_PROCESS_ADDRESSES", container); val == "" {
+					val, _ := getEnvironmentVariable("TPU_PROCESS_ADDRESSES", container)
+					if val == "" || strings.Contains(val, "localhost") {
+						// Inject value if unset or set to default value.
 						processAddresses, err := getTPUProcessAdresses(numOfHosts, numTpuContainers, groupName, clusterName, replicaIndex)
 						if err != nil {
 							return nil, err
@@ -904,41 +918,27 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 				}
 			}
 			// inject TPU_WORKER_ID
-			if value, _ := getEnvironmentVariable("TPU_WORKER_ID", container); value == "" {
+			valWorkerID, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
+			expectedID := fmt.Sprint(finalWorkerID)
+			isDefault := valWorkerID == fmt.Sprint(tpuContainerIndex)
+
+			if valWorkerID == "" || (isDefault && valWorkerID != expectedID) {
+				// Overwrite ID if set incorrectly by user, or set to default erroneously in a multi-host env.
 				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_ID", finalWorkerID, "Replica Index", replicaIndex)
 				workerID := corev1.EnvVar{
 					Name:  "TPU_WORKER_ID",
 					Value: fmt.Sprint(finalWorkerID),
 				}
-				idPatch := patch{"op": "add"}
-				// create new EnvVar array if container.Env is empty, and append new EnvVars if not
-				if len(container.Env) == 0 {
-					idPatch["path"] = path
-					idPatch["value"] = []corev1.EnvVar{workerID}
-				} else {
-					idPatch["path"] = fmt.Sprintf("%s/-", path)
-					idPatch["value"] = workerID
-				}
-				patches = append(patches, idPatch)
+				patches, isEnvInitialized = addEnvVarPatch(patches, workerID, path, isEnvInitialized)
 			}
 			// inject TPU_NAME
 			if value, _ := getEnvironmentVariable("TPU_NAME", container); value == "" {
 				tpuNameValue := fmt.Sprintf("%s-%d", groupName, replicaIndex)
 				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_NAME", tpuNameValue, "Replica Index", replicaIndex)
-				tpuName := corev1.EnvVar{
+				patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{
 					Name:  "TPU_NAME",
 					Value: tpuNameValue,
-				}
-				namePatch := patch{"op": "add"}
-				// create new EnvVar array if container.Env is empty, and append new EnvVars if not
-				if len(container.Env) == 0 {
-					namePatch["path"] = path
-					namePatch["value"] = []corev1.EnvVar{tpuName}
-				} else {
-					namePatch["path"] = fmt.Sprintf("%s/-", path)
-					namePatch["value"] = tpuName
-				}
-				patches = append(patches, namePatch)
+				}, path, isEnvInitialized)
 			}
 
 			// inject TPU_DEVICE_PLUGIN_HOST_IP. This Env Var is required for TPU_DEVICE_PLUGIN_ADDR
@@ -952,36 +952,17 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 						},
 					},
 				}
-				hostAddrPatch := patch{"op": "add"}
-				// create new EnvVar array if container.Env is empty, and append new envVars if not
-				if len(container.Env) == 0 {
-					hostAddrPatch["path"] = path
-					hostAddrPatch["value"] = []corev1.EnvVar{tpuDevicePluginAddr}
-				} else {
-					hostAddrPatch["path"] = fmt.Sprintf("%s/-", path)
-					hostAddrPatch["value"] = tpuDevicePluginAddr
-				}
-				patches = append(patches, hostAddrPatch)
+				patches, isEnvInitialized = addEnvVarPatch(patches, tpuDevicePluginAddr, path, isEnvInitialized)
 			}
 
 			// inject TPU_DEVICE_PLUGIN_ADDR
 			if value, _ := getEnvironmentVariable("TPU_DEVICE_PLUGIN_ADDR", container); value == "" {
 				tpuDevicePluginAddrValue := "$(TPU_DEVICE_PLUGIN_HOST_IP):2112"
 				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_DEVICE_PLUGIN_ADDR", tpuDevicePluginAddrValue)
-				tpuDevicePluginAddr := corev1.EnvVar{
+				patches, isEnvInitialized = addEnvVarPatch(patches, corev1.EnvVar{
 					Name:  "TPU_DEVICE_PLUGIN_ADDR",
 					Value: tpuDevicePluginAddrValue,
-				}
-				pluginAddrPatch := patch{"op": "add"}
-				// create new EnvVar array if container.Env is empty, and append new EnvVars if not
-				if len(container.Env) == 0 {
-					pluginAddrPatch["path"] = path
-					pluginAddrPatch["value"] = []corev1.EnvVar{tpuDevicePluginAddr}
-				} else {
-					pluginAddrPatch["path"] = fmt.Sprintf("%s/-", path)
-					pluginAddrPatch["value"] = tpuDevicePluginAddr
-				}
-				patches = append(patches, pluginAddrPatch)
+				}, path, isEnvInitialized)
 			}
 			tpuContainerIndex++
 		}

--- a/main.go
+++ b/main.go
@@ -283,9 +283,9 @@ func genDNSHostnames(numOfHosts int32, groupName string, clusterName string, nam
 	return strings.Join(hostNames, ","), nil
 }
 
-// getTPUProcessAdresses returns the list of process addresses (host:port) for all containers in the slice.
+// getTPUProcessAddresses returns the list of process addresses (host:port) for all containers in the slice.
 // The base port is 8476. TPU_PROCESS_ADDRESSES replaces TPU_WORKER_HOSTNAMES for Ironwood (v7x) TPUs and newer.
-func getTPUProcessAdresses(numOfHosts int32, numTpuContainers int, groupName, clusterName string, replicaIndex int) (string, error) {
+func getTPUProcessAddresses(numOfHosts int32, numTpuContainers int, groupName, clusterName string, replicaIndex int) (string, error) {
 	if numOfHosts == 0 {
 		return "", errors.New("workerGroupSpec NumOfHosts not set")
 	}
@@ -906,7 +906,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					val, _ := getEnvironmentVariable("TPU_PROCESS_ADDRESSES", container)
 					if val == "" || strings.Contains(val, "localhost") {
 						// Inject value if unset or set to default value.
-						processAddresses, err := getTPUProcessAdresses(numOfHosts, numTpuContainers, groupName, clusterName, replicaIndex)
+						processAddresses, err := getTPUProcessAddresses(numOfHosts, numTpuContainers, groupName, clusterName, replicaIndex)
 						if err != nil {
 							return nil, err
 						}

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ var (
 	tpuResourceName = corev1.ResourceName("google.com/tpu")
 
 	// TPU related constants.
-	tpuProcessPortBase = 8476
+	tpuProcessPortBase = 8471
 	megascalePortBase  = 8081
 
 	// Flag arguments.
@@ -875,8 +875,16 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 			}
 			// Network addressing injection logic.
 			if numOfHosts > 1 {
+				// Legacy: inject TPU_WORKER_HOSTNAMES
+				hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
+				if err != nil {
+					return nil, err
+				}
+				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
+				injectHostnames(clusterName, hostnames, path, container, &patches)
+
 				if isV7x {
-					// v7x: Inject TPU_PROCESS_ADDRESSES & TPU_PROCESS_PORT
+					// v7x only: Inject TPU_PROCESS_ADDRESSES & TPU_PROCESS_PORT
 					if val, _ := getEnvironmentVariable("TPU_PROCESS_ADDRESSES", container); val == "" {
 						processAddresses, err := getTPUProcessAdresses(numOfHosts, numTpuContainers, groupName, clusterName, replicaIndex)
 						if err != nil {
@@ -889,14 +897,6 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					if val, _ := getEnvironmentVariable("TPU_PROCESS_PORT", container); val == "" {
 						patches, _ = addEnvVarPatch(patches, corev1.EnvVar{Name: "TPU_PROCESS_PORT", Value: fmt.Sprint(tpuProcessPortBase + tpuContainerIndex)}, path, true)
 					}
-				} else {
-					// Legacy: inject TPU_WORKER_HOSTNAMES
-					hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
-					if err != nil {
-						return nil, err
-					}
-					klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
-					injectHostnames(clusterName, hostnames, path, container, &patches)
 				}
 			}
 			// inject TPU_WORKER_ID

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1866,8 +1866,8 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 			clusterName:      "test-cluster",
 			replicaIndex:     0,
 			expected: strings.Join([]string{
-				fmt.Sprintf("test-group-0-0.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
-				fmt.Sprintf("test-group-0-0.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-0-0.test-cluster-%s:8471", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-0-0.test-cluster-%s:8472", utils.HeadlessServiceSuffix),
 			}, ","),
 		},
 		"getTPUProcessAdresses multi-host, multi-container.": {
@@ -1877,10 +1877,10 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 			clusterName:      "test-cluster",
 			replicaIndex:     1,
 			expected: strings.Join([]string{
-				fmt.Sprintf("test-group-1-0.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
-				fmt.Sprintf("test-group-1-0.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
-				fmt.Sprintf("test-group-1-1.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
-				fmt.Sprintf("test-group-1-1.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-0.test-cluster-%s:8471", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-0.test-cluster-%s:8472", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-1.test-cluster-%s:8471", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-1.test-cluster-%s:8472", utils.HeadlessServiceSuffix),
 			}, ","),
 		},
 	}
@@ -1916,7 +1916,7 @@ func Test_MutatePod_V7x(t *testing.T) {
 			numOfHosts:              2,
 			customEnv:               nil,
 			expectedWorkerID:        "1",
-			expectedPort:            "8477", // Base port + 1
+			expectedPort:            "8472", // Base port + 1
 			expectedLogDir:          "/tmp/tpu-logs/ray-worker-2",
 			expectPatchForAddresses: true,
 			expectPatchForPort:      true,
@@ -1940,7 +1940,7 @@ func Test_MutatePod_V7x(t *testing.T) {
 				{Name: "MEGASCALE_NUM_SLICES", Value: "2"},
 			},
 			expectedWorkerID:        "1",
-			expectedPort:            "8477",
+			expectedPort:            "8472",
 			expectedLogDir:          "/tmp/tpu-logs/ray-worker-2",
 			expectedMegascalePort:   "8082", // Base port + 1
 			expectedMegascaleCoord:  fmt.Sprintf("test-group-0-0.test-cluster-%s:8081", utils.HeadlessServiceSuffix),

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -653,64 +653,73 @@ func Test_GetNumTPUHostsFromTopology(t *testing.T) {
 }
 
 func Test_GetNumTPUChipsRequested(t *testing.T) {
+	// Helper to create a container with specific TPU request/limit.
+	makeContainer := func(name string, req, lim string) corev1.Container {
+		c := corev1.Container{Name: name, Resources: corev1.ResourceRequirements{}}
+		if req != "" {
+			c.Resources.Requests = corev1.ResourceList{"google.com/tpu": resource.MustParse(req)}
+		}
+		if lim != "" {
+			c.Resources.Limits = corev1.ResourceList{"google.com/tpu": resource.MustParse(lim)}
+		}
+		return c
+	}
+
 	tests := map[string]struct {
-		testPod            *corev1.Pod
-		expectedTPULimit   map[corev1.ResourceName]resource.Quantity
-		expectedTPURequest map[corev1.ResourceName]resource.Quantity
-		expectedNumChips   int64
+		containers       []corev1.Container
+		expectedNumChips int64
 	}{
-		"getNumTPUChipsRequested no TPUs requested": {
+		"Single container, no TPUs": {
 			// doesn't request TPUs - returns 0
-			testPod:            getTestCPUWorker("test-cluster", "test-group", "test-namespace"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("0")},
-			expectedTPURequest: map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("0")},
-			expectedNumChips:   int64(0),
+			containers: []corev1.Container{
+				makeContainer("c1", "0", "0"),
+			},
+			expectedNumChips: 0,
 		},
-		"getNumTPUChipsRequested only TPU limit resource set": {
+		"Single container, explicit Request": {
+			// includes standard TPU request of 4 chips
+			containers: []corev1.Container{
+				makeContainer("c1", "4", "4"),
+			},
+			expectedNumChips: 4,
+		},
+		"Single container, only TPU limit specified": {
 			// includes TPU limits but omits request - defaults to limit value
-			testPod:            getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v4-podslice", "2x2x1", "4"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("4")},
-			expectedTPURequest: nil,
-			expectedNumChips:   int64(4),
+			containers: []corev1.Container{
+				makeContainer("c1", "", "4"),
+			},
+			expectedNumChips: 4,
 		},
-		"getNumTPUChipsRequested with TPU Request > TPU Limit": {
-			// TPU Limit = maximum number of TPU chips requested
-			testPod:            getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v4-podslice", "2x2x1", "4"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("4")},
-			expectedTPURequest: map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("8")},
-			expectedNumChips:   int64(4),
+		"Multiple containers with TPU requests": {
+			containers: []corev1.Container{
+				makeContainer("c1", "2", "2"),
+				makeContainer("c2", "2", "2"),
+			},
+			expectedNumChips: 4,
 		},
-		"getNumTPUChipsRequested with v4 TPU request": {
-			// v4 - always 4 chips per VM
-			testPod:            getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v4-podslice", "2x2x2", "4"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("4")},
-			expectedTPURequest: map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("4")},
-			expectedNumChips:   int64(4),
+		"Multiple containers with TPU limits": {
+			containers: []corev1.Container{
+				makeContainer("c1", "1", "4"), // Request takes precedence over limit
+				makeContainer("c2", "", "2"),  // Request defaults to limit
+			},
+			expectedNumChips: 3,
 		},
-		"getNumTPUChipsRequested with v5e ct5lp-hightpu-1t TPU request": {
-			// v5e - 1x1 and 1 chip per VM
-			testPod:            getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v5-lite-podslice", "1x1", "1"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("1")},
-			expectedTPURequest: map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("1")},
-			expectedNumChips:   int64(1),
-		},
-		"getNumTPUChipsRequested with v5e ct5lp-hightpu-8t TPU request": {
-			// v5e - 2x4 and 8 chips per VM
-			testPod:            getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v5-lite-podslice", "2x4", "8"),
-			expectedTPULimit:   map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("8")},
-			expectedTPURequest: map[corev1.ResourceName]resource.Quantity{"google.com/tpu": resource.MustParse("8")},
-			expectedNumChips:   int64(8),
+		"Multiple containers with TPU and non-TPU": {
+			containers: []corev1.Container{
+				makeContainer("c1", "4", "4"),
+				{Name: "sidecar", Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{"cpu": resource.MustParse("1")},
+				}},
+			},
+			expectedNumChips: 4,
 		},
 	}
 
 	// validate that getNumTPUChipsRequested correctly returns the number of TPU chips requested per Pod container
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			container := tc.testPod.Spec.Containers[0]
-			container.Resources.Limits = tc.expectedTPULimit
-			container.Resources.Requests = tc.expectedTPURequest
-			chipsPerHost := getNumTPUChipsRequested(container)
-			assert.Equal(t, tc.expectedNumChips, chipsPerHost)
+			chips := getNumTPUChipsRequested(tc.containers...)
+			assert.Equal(t, tc.expectedNumChips, chips)
 		})
 	}
 }

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -413,36 +413,36 @@ func setupInformer(pods ...*corev1.Pod) listersv1.PodLister {
 
 func Test_GetReplicaIndex(t *testing.T) {
 	tests := map[string]struct {
-		sliceToWorkerIDs     map[slice][]int
+		sliceToTPUHosts      map[slice][]int
 		expectedReplicaIndex int
 	}{
-		"nil sliceToWorkerIDs": {
+		"nil sliceToTPUHosts": {
 			// defaults to assigning Pod to replica 0
-			sliceToWorkerIDs:     nil,
+			sliceToTPUHosts:      nil,
 			expectedReplicaIndex: 0,
 		},
-		"empty sliceToWorkerIDs": {
+		"empty sliceToTPUHosts": {
 			// should assign Pod to replica 0 since no other Pods in slice
-			sliceToWorkerIDs:     make(map[slice][]int),
+			sliceToTPUHosts:      make(map[slice][]int),
 			expectedReplicaIndex: 0,
 		},
 		"single-host worker group missing worker": {
 			// should assign Pod to replica 0 since # workers < 1 for that slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)}: []int{},
 			},
 			expectedReplicaIndex: 0,
 		},
 		"single-host worker group with all workers created": {
 			// should assign Pod to replica 1 since one existing slice with all workers created
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)}: []int{0},
 			},
 			expectedReplicaIndex: 1,
 		},
 		"multi-host worker group missing worker": {
 			// should assign Pod to replica 0 since # workers < 4 for that slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2, 3},
 			},
@@ -450,14 +450,14 @@ func Test_GetReplicaIndex(t *testing.T) {
 		},
 		"multi-host worker group with all workers created": {
 			// should assign Pod to replica 1 since one existing slice with all workers created
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 			},
 			expectedReplicaIndex: 1,
 		},
 		"multi-slice worker group": {
 			// should assign Pod to replica 4 since 3 existing slices with all workers created
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 2, int32(4)}: []int{0, 1, 2, 3},
@@ -469,7 +469,7 @@ func Test_GetReplicaIndex(t *testing.T) {
 	// validate getReplicaIndex() returns the expected Replica ID for TPU pods in varying pod slices
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			replicaIndex := getReplicaIndex(tc.sliceToWorkerIDs, "test-cluster", "test-group", "test-namespace")
+			replicaIndex := getReplicaIndex(tc.sliceToTPUHosts, "test-cluster", "test-group", "test-namespace")
 			assert.Equal(t, tc.expectedReplicaIndex, replicaIndex)
 		})
 	}
@@ -477,29 +477,29 @@ func Test_GetReplicaIndex(t *testing.T) {
 
 func Test_GetNextWorkerID(t *testing.T) {
 	tests := map[string]struct {
-		sliceToWorkerIDs    map[slice][]int
+		sliceToTPUHosts     map[slice][]int
 		podSlice            slice
 		replicaIndex        int
 		expectedError       error
 		expectedTPUWorkerID int
 	}{
-		"nil sliceToWorkerIDs": {
+		"nil sliceToTPUHosts": {
 			// defaults to assigning Pod to TPU_WORKER_ID=0
-			sliceToWorkerIDs:    nil,
+			sliceToTPUHosts:     nil,
 			podSlice:            slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)},
 			replicaIndex:        0,
 			expectedTPUWorkerID: 0,
 		},
-		"empty sliceToWorkerIDs": {
+		"empty sliceToTPUHosts": {
 			// should assign Pod to TPU_WORKER_ID=0 since no other Pods in slice
-			sliceToWorkerIDs:    make(map[slice][]int),
+			sliceToTPUHosts:     make(map[slice][]int),
 			podSlice:            slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)},
 			replicaIndex:        0,
 			expectedTPUWorkerID: 0,
 		},
 		"single-host worker group with empty worker ID list": {
 			// should assign Pod to TPU_WORKER_ID=0 since # workers < 1 for that slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)}: []int{},
 			},
 			podSlice:            slice{"test-cluster", "test-group", "test-namespace", 0, int32(1)},
@@ -508,7 +508,7 @@ func Test_GetNextWorkerID(t *testing.T) {
 		},
 		"multi-host worker group with deleted worker": {
 			// should assign Pod to TPU_WORKER_ID=2 since that's the next lowest int ID in the slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{3, 0, 1},
 			},
 			podSlice:            slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)},
@@ -517,7 +517,7 @@ func Test_GetNextWorkerID(t *testing.T) {
 		},
 		"multi-host worker group with # worker IDs < NumOfHosts": {
 			// should assign Pod to TPU_WORKER_ID=3 since that's the next lowest int ID in the slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2},
 			},
@@ -527,7 +527,7 @@ func Test_GetNextWorkerID(t *testing.T) {
 		},
 		"multi-host worker group with incorrectly assigned worker IDs": {
 			// should error since two or more Pods in a slice have identical TPU_WORKER_IDs
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 1},
 			},
@@ -537,7 +537,7 @@ func Test_GetNextWorkerID(t *testing.T) {
 		},
 		"multi-slice worker group with all workers created": {
 			// should always assign Pod to TPU_WORKER_ID=0 in a new slice
-			sliceToWorkerIDs: map[slice][]int{
+			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 2, int32(4)}: []int{0, 1, 2, 3},
@@ -548,10 +548,10 @@ func Test_GetNextWorkerID(t *testing.T) {
 		},
 	}
 
-	// validate getNextWorkerID() returns the expected TPU_WORKER ID for different sliceToWorkerIDs
+	// validate getNextWorkerID() returns the expected TPU_WORKER ID for different sliceToTPUHosts
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			workerID, err := getNextWorkerID(tc.sliceToWorkerIDs, tc.podSlice, "test-namespace", tc.replicaIndex)
+			workerID, err := getNextWorkerID(tc.sliceToTPUHosts, tc.podSlice, "test-namespace", tc.replicaIndex)
 			if err != nil {
 				assert.Equal(t, tc.expectedError, err)
 			}
@@ -904,7 +904,7 @@ func Test_InjectHostnames(t *testing.T) {
 			testPod := getTestTPUWorker(tc.clusterName, tc.groupName, "test-namespace", "tpu-v4-podslice", "2x2x2", "4")
 			expectedEnv := []corev1.EnvVar{corev1.EnvVar{Name: "TPU_WORKER_HOSTNAMES", Value: tc.expectedHostnames}}
 			patches := []patch{}
-			injectHostnames(tc.clusterName, tc.expectedHostnames, "/spec/containers/0/env", testPod.Spec.Containers[0], &patches)
+			injectHostnames(tc.clusterName, tc.expectedHostnames, "/spec/containers/0/env", testPod.Spec.Containers[0], &patches, false)
 			// check hostnames patch
 			assert.Equal(t, "/spec/containers/0/env", patches[0]["path"])
 			assert.Equal(t, expectedEnv, patches[0]["value"])
@@ -1302,7 +1302,7 @@ func Test_GetEnvironmentVariable(t *testing.T) {
 	}
 }
 
-func Test_GetSliceToWorkerIDs(t *testing.T) {
+func Test_getSliceToTPUHosts(t *testing.T) {
 	testCPUWorker := getTestCPUWorker("test-cluster", "test-group", "test-namespace")
 	testTPUWorker := getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v4-podslice", "2x2x2", "4")
 	expectedIds := make([]int, 64)
@@ -1311,30 +1311,30 @@ func Test_GetSliceToWorkerIDs(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		numOfHosts               int32
-		numReplicas              int
-		podsInGroup              []*corev1.Pod
-		expectedSliceToWorkerIDs map[slice][]int
+		numOfHosts              int32
+		numReplicas             int
+		podsInGroup             []*corev1.Pod
+		expectedsliceToTPUHosts map[slice][]int
 	}{
-		"getSliceToWorkerIDs with nil Pod list": {
+		"getSliceToTPUHosts with nil Pod list": {
 			// this can occur when no Pods with the Ray group name have been cached
 			// should return an empty mapping
-			podsInGroup:              nil,
-			expectedSliceToWorkerIDs: make(map[slice][]int),
+			podsInGroup:             nil,
+			expectedsliceToTPUHosts: make(map[slice][]int),
 		},
-		"getSliceToWorkerIDs for with CPU pod list": {
-			// sliceToWorkerIDs should return an empty mapping
-			numOfHosts:               int32(1),
-			numReplicas:              4,
-			podsInGroup:              getTestPods(testCPUWorker, "test-cluster", "test-namespace", 4),
-			expectedSliceToWorkerIDs: make(map[slice][]int),
+		"getSliceToTPUHosts for with CPU pod list": {
+			// sliceToTPUHosts should return an empty mapping
+			numOfHosts:              int32(1),
+			numReplicas:             4,
+			podsInGroup:             getTestPods(testCPUWorker, "test-cluster", "test-namespace", 4),
+			expectedsliceToTPUHosts: make(map[slice][]int),
 		},
-		"getSliceToWorkerIDs for with TPU pod list": {
-			// sliceToWorkerIDs should be populated with TPU worker IDs
+		"getSliceToTPUHosts for with TPU pod list": {
+			// sliceToTPUHosts should be populated with TPU worker IDs
 			numOfHosts:  int32(64),
 			numReplicas: 2,
 			podsInGroup: getTestInterceptedTPUPods(testTPUWorker, 128, 2, 64),
-			expectedSliceToWorkerIDs: map[slice][]int{
+			expectedsliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(64)}: expectedIds,
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(64)}: expectedIds,
 			},
@@ -1345,16 +1345,16 @@ func Test_GetSliceToWorkerIDs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			podLister := setupInformer(tc.podsInGroup...)
 			tpuWebhook := NewTPUWebhookServer(podLister)
-			sliceToWorkerIDs, err := tpuWebhook.getSliceToWorkerIDs("test-cluster", "test-group", "test-namespace", tc.numOfHosts)
+			sliceToTPUHosts, err := tpuWebhook.getSliceToTPUHosts("test-cluster", "test-group", "test-namespace", tc.numOfHosts)
 
-			// sliceToWorkerIDs should be populated with slices and unique TPU_WORKER_IDs for each Pod
+			// sliceToTPUHosts should be populated with slices and unique TPU_WORKER_IDs for each Pod
 			assert.Equal(t, err, nil)
-			for slice, workerIDs := range sliceToWorkerIDs {
-				assert.Contains(t, tc.expectedSliceToWorkerIDs, slice)
-				assert.Equal(t, len(tc.expectedSliceToWorkerIDs[slice]), len(workerIDs))
+			for slice, workerIDs := range sliceToTPUHosts {
+				assert.Contains(t, tc.expectedsliceToTPUHosts, slice)
+				assert.Equal(t, len(tc.expectedsliceToTPUHosts[slice]), len(workerIDs))
 				sort.Ints(workerIDs)
 				for index, value := range workerIDs {
-					assert.Equal(t, tc.expectedSliceToWorkerIDs[slice][index], value)
+					assert.Equal(t, tc.expectedsliceToTPUHosts[slice][index], value)
 				}
 			}
 		})

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1851,7 +1851,7 @@ func TestWebhookCertReloadsOnChange(t *testing.T) {
 	t.Logf("Server successfully reloaded the certificate with cert-watcher.")
 }
 
-func Test_GetTPUProcessAdresses(t *testing.T) {
+func Test_GetTPUProcessAddresses(t *testing.T) {
 	tests := map[string]struct {
 		numOfHosts       int32
 		numTpuContainers int
@@ -1860,7 +1860,7 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 		expected         string
 		expectedError    error
 	}{
-		"getTPUProcessAdresses with NumOfHosts == 0": {
+		"getTPUProcessAddresses with NumOfHosts == 0": {
 			// Invalid case - NumOfHosts can't be 0.
 			numOfHosts:       0,
 			numTpuContainers: 2,
@@ -1868,7 +1868,7 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 			replicaIndex:     0,
 			expectedError:    errors.New("workerGroupSpec NumOfHosts not set"),
 		},
-		"getTPUProcessAdresses single host, multi-container": {
+		"getTPUProcessAddresses single host, multi-container": {
 			// 1 host, 2 containers -> generates 2 ports on host 0.
 			numOfHosts:       1,
 			numTpuContainers: 2,
@@ -1879,7 +1879,7 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 				fmt.Sprintf("test-group-0-0.test-cluster-%s:8472", utils.HeadlessServiceSuffix),
 			}, ","),
 		},
-		"getTPUProcessAdresses multi-host, multi-container.": {
+		"getTPUProcessAddresses multi-host, multi-container.": {
 			// 2 hosts, 2 containers -> generates 4 addresses.
 			numOfHosts:       2,
 			numTpuContainers: 2,
@@ -1896,7 +1896,7 @@ func Test_GetTPUProcessAdresses(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual, err := getTPUProcessAdresses(tc.numOfHosts, tc.numTpuContainers, "test-group", tc.clusterName, tc.replicaIndex)
+			actual, err := getTPUProcessAddresses(tc.numOfHosts, tc.numTpuContainers, "test-group", tc.clusterName, tc.replicaIndex)
 
 			if tc.expectedError != nil {
 				assert.Equal(t, tc.expectedError, err)

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -863,15 +863,13 @@ func Test_InjectHostnames(t *testing.T) {
 	tests := map[string]struct {
 		clusterName       string
 		groupName         string
-		expectedSubdomain string
 		expectedHostnames string
 	}{
 		"injectHostnames for multi-host worker group": {
-			// Should create a patch to set the subdomain and TPU_WORKER_HOSTNAMES for all hosts.
+			// Should create a patch to set TPU_WORKER_HOSTNAMES for all hosts.
 			// This function is only called for multi-host TPU worker groups.
-			clusterName:       "test-cluster",
-			groupName:         "test-group-name",
-			expectedSubdomain: fmt.Sprintf("%s-%s", "test-cluster", utils.HeadlessServiceSuffix),
+			clusterName: "test-cluster",
+			groupName:   "test-group-name",
 			expectedHostnames: strings.Join([]string{fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 0, "test-cluster", utils.HeadlessServiceSuffix),
 				fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 1, "test-cluster", utils.HeadlessServiceSuffix),
 				fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 2, "test-cluster", utils.HeadlessServiceSuffix),
@@ -879,11 +877,10 @@ func Test_InjectHostnames(t *testing.T) {
 			}, ","),
 		},
 		"injectHostnames for multi-host worker group with truncated service name": {
-			// Should create a patch to set the subdomain and TPU_WORKER_HOSTNAMES for all hosts, with the
+			// Should create a patch to set the TPU_WORKER_HOSTNAMES for all hosts, with the
 			// correct subdomain truncated to match the created service name.
-			clusterName:       "really-really-extremely-long-test-raycluster-name",
-			groupName:         "test-group-name",
-			expectedSubdomain: fmt.Sprintf("%s-%s", "eally-extremely-long-test-raycluster-name", utils.HeadlessServiceSuffix),
+			clusterName: "really-really-extremely-long-test-raycluster-name",
+			groupName:   "test-group-name",
 			expectedHostnames: strings.Join([]string{fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 0, "eally-extremely-long-test-raycluster-name", utils.HeadlessServiceSuffix),
 				fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 1, "eally-extremely-long-test-raycluster-name", utils.HeadlessServiceSuffix),
 				fmt.Sprintf("%s-%d-%d.%s-%s", "test-group", 1, 2, "eally-extremely-long-test-raycluster-name", utils.HeadlessServiceSuffix),
@@ -892,19 +889,44 @@ func Test_InjectHostnames(t *testing.T) {
 		},
 	}
 
-	// check that a valid subdomain and TPU_WORKER_HOSTNAMES are injected into the Pod
+	// check that valid TPU_WORKER_HOSTNAMES are injected into the Pod
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			testPod := getTestTPUWorker(tc.clusterName, tc.groupName, "test-namespace", "tpu-v4-podslice", "2x2x2", "4")
 			expectedEnv := []corev1.EnvVar{corev1.EnvVar{Name: "TPU_WORKER_HOSTNAMES", Value: tc.expectedHostnames}}
 			patches := []patch{}
 			injectHostnames(tc.clusterName, tc.expectedHostnames, "/spec/containers/0/env", testPod.Spec.Containers[0], &patches)
-			// check subdomain patch
+			// check hostnames patch
+			assert.Equal(t, "/spec/containers/0/env", patches[0]["path"])
+			assert.Equal(t, expectedEnv, patches[0]["value"])
+		})
+	}
+}
+
+func Test_InjectSubdomain(t *testing.T) {
+	tests := map[string]struct {
+		clusterName       string
+		expectedSubdomain string
+	}{
+		"injectSubdomain sets correct headless service name": {
+			clusterName:       "test-cluster",
+			expectedSubdomain: fmt.Sprintf("%s-%s", "test-cluster", utils.HeadlessServiceSuffix),
+		},
+		"injectSubdomain handles truncated service name": {
+			clusterName:       "really-really-extremely-long-test-raycluster-name",
+			expectedSubdomain: fmt.Sprintf("%s-%s", "eally-extremely-long-test-raycluster-name", utils.HeadlessServiceSuffix),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			patches := []patch{}
+			injectSubdomain(tc.clusterName, &patches)
+
+			// verify that the subdomain is injected correctly
+			assert.Len(t, patches, 1)
 			assert.Equal(t, "/spec/subdomain", patches[0]["path"])
 			assert.Equal(t, tc.expectedSubdomain, patches[0]["value"])
-			// check hostnames patch
-			assert.Equal(t, "/spec/containers/0/env", patches[1]["path"])
-			assert.Equal(t, expectedEnv, patches[1]["value"])
 		})
 	}
 }
@@ -1818,4 +1840,205 @@ func TestWebhookCertReloadsOnChange(t *testing.T) {
 	// Final check to ensure the new cert is different from the old one.
 	assert.NotEqual(t, initialCert.SerialNumber, reloadedCert.SerialNumber, "Certificate was not reloaded; serial number is unchanged.")
 	t.Logf("Server successfully reloaded the certificate with cert-watcher.")
+}
+
+func Test_GetTPUProcessAdresses(t *testing.T) {
+	tests := map[string]struct {
+		numOfHosts       int32
+		numTpuContainers int
+		clusterName      string
+		replicaIndex     int
+		expected         string
+		expectedError    error
+	}{
+		"getTPUProcessAdresses with NumOfHosts == 0": {
+			// Invalid case - NumOfHosts can't be 0.
+			numOfHosts:       0,
+			numTpuContainers: 2,
+			clusterName:      "test-cluster",
+			replicaIndex:     0,
+			expectedError:    errors.New("workerGroupSpec NumOfHosts not set"),
+		},
+		"getTPUProcessAdresses single host, multi-container": {
+			// 1 host, 2 containers -> generates 2 ports on host 0.
+			numOfHosts:       1,
+			numTpuContainers: 2,
+			clusterName:      "test-cluster",
+			replicaIndex:     0,
+			expected: strings.Join([]string{
+				fmt.Sprintf("test-group-0-0.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-0-0.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
+			}, ","),
+		},
+		"getTPUProcessAdresses multi-host, multi-container.": {
+			// 2 hosts, 2 containers -> generates 4 addresses.
+			numOfHosts:       2,
+			numTpuContainers: 2,
+			clusterName:      "test-cluster",
+			replicaIndex:     1,
+			expected: strings.Join([]string{
+				fmt.Sprintf("test-group-1-0.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-0.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-1.test-cluster-%s:8476", utils.HeadlessServiceSuffix),
+				fmt.Sprintf("test-group-1-1.test-cluster-%s:8477", utils.HeadlessServiceSuffix),
+			}, ","),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := getTPUProcessAdresses(tc.numOfHosts, tc.numTpuContainers, "test-group", tc.clusterName, tc.replicaIndex)
+
+			if tc.expectedError != nil {
+				assert.Equal(t, tc.expectedError, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_MutatePod_V7x(t *testing.T) {
+	tests := map[string]struct {
+		numOfHosts              int32
+		customEnv               []corev1.EnvVar
+		expectedWorkerID        string
+		expectedPort            string
+		expectedLogDir          string
+		expectedMegascalePort   string
+		expectedMegascaleCoord  string
+		expectPatchForAddresses bool
+		expectPatchForPort      bool
+		isMultiSlice            bool
+	}{
+		"v7x standard multi-container injection": {
+			numOfHosts:              2,
+			customEnv:               nil,
+			expectedWorkerID:        "1",
+			expectedPort:            "8477", // Base port + 1
+			expectedLogDir:          "/tmp/tpu-logs/ray-worker-2",
+			expectPatchForAddresses: true,
+			expectPatchForPort:      true,
+			isMultiSlice:            false,
+		},
+		"v7x respects user-defined ports and addresses": {
+			numOfHosts: 2,
+			customEnv: []corev1.EnvVar{
+				{Name: "TPU_PROCESS_PORT", Value: "9999"},
+				{Name: "TPU_PROCESS_ADDRESSES", Value: "custom-mesh:9999"},
+			},
+			expectedWorkerID:        "1",
+			expectedLogDir:          "/tmp/tpu-logs/ray-worker-2",
+			expectPatchForAddresses: false,
+			expectPatchForPort:      false,
+			isMultiSlice:            false,
+		},
+		"v7x megascale multi-slice coordination": {
+			numOfHosts: 2,
+			customEnv: []corev1.EnvVar{
+				{Name: "MEGASCALE_NUM_SLICES", Value: "2"},
+			},
+			expectedWorkerID:        "1",
+			expectedPort:            "8477",
+			expectedLogDir:          "/tmp/tpu-logs/ray-worker-2",
+			expectedMegascalePort:   "8082", // Base port + 1
+			expectedMegascaleCoord:  fmt.Sprintf("test-group-0-0.test-cluster-%s:8081", utils.HeadlessServiceSuffix),
+			expectPatchForAddresses: true,
+			expectPatchForPort:      true,
+			isMultiSlice:            true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			inputPod := getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu7x-standard-4t", "2x2x2", "2")
+
+			// Add user-specified env vars
+			if tc.customEnv != nil {
+				inputPod.Spec.Containers[0].Env = append(inputPod.Spec.Containers[0].Env, tc.customEnv...)
+			}
+
+			// Add a second container that requests TPU.
+			secondContainer := inputPod.Spec.Containers[0].DeepCopy()
+			secondContainer.Name = "ray-worker-2"
+			inputPod.Spec.Containers = append(inputPod.Spec.Containers, *secondContainer)
+
+			admissionReview := getTestAdmissionReview("Pod", "CREATE")
+			jsonPod, _ := json.Marshal(inputPod)
+			admissionReview.Request.Object.Raw = jsonPod
+			admissionReview.Request.Object.Object = inputPod
+
+			testPodLister := setupInformer()
+			tpuWebhookServer := NewTPUWebhookServer(testPodLister)
+
+			// Validate Pod mutation for a Ironwood (v7x) TPU Pod contains the expected patches.
+			admissionResponse, err := tpuWebhookServer.mutatePod(admissionReview)
+			assert.NoError(t, err)
+
+			var patches []patch
+			json.Unmarshal(admissionResponse.Patch, &patches)
+
+			// Helper to find Env Var patches per container
+			findContainerEnvPatch := func(name string) map[string]interface{} {
+				for _, p := range patches {
+					if p["path"] == "/spec/containers/1/env" || p["path"] == "/spec/containers/1/env/-" {
+						if valList, ok := p["value"].([]interface{}); ok {
+							for _, v := range valList {
+								if vMap, ok := v.(map[string]interface{}); ok {
+									if vMap["name"] == name {
+										return vMap
+									}
+								}
+							}
+						}
+						if valMap, ok := p["value"].(map[string]interface{}); ok {
+							if valMap["name"] == name {
+								return valMap
+							}
+						}
+					}
+				}
+				return nil
+			}
+
+			// Check TPU_WORKER_ID, should be unique per container in the slice.
+			workerIDMap := findContainerEnvPatch("TPU_WORKER_ID")
+			assert.NotNil(t, workerIDMap, "TPU_WORKER_ID patch missing")
+			assert.Equal(t, tc.expectedWorkerID, workerIDMap["value"])
+
+			// Check TPU_NAME, this is a unique ID for the TPU slice.
+			tpuNameMap := findContainerEnvPatch("TPU_NAME")
+			assert.NotNil(t, tpuNameMap, "TPU_NAME patch missing")
+			assert.Equal(t, "test-group-0", tpuNameMap["value"])
+
+			// Check networking related fields and env vars
+			addressMap := findContainerEnvPatch("TPU_PROCESS_ADDRESSES")
+			if tc.expectPatchForAddresses {
+				assert.NotNil(t, addressMap, "Expected TPU_PROCESS_ADDRESSES patch")
+				assert.Contains(t, addressMap["value"].(string), "test-group-0-0")
+			} else {
+				assert.Nil(t, addressMap, "Webhook overwrote user-defined TPU_PROCESS_ADDRESSES")
+			}
+
+			portMap := findContainerEnvPatch("TPU_PROCESS_PORT")
+			if tc.expectPatchForPort {
+				assert.NotNil(t, portMap, "Expected TPU_PROCESS_PORT patch")
+				assert.Equal(t, tc.expectedPort, portMap["value"])
+			} else {
+				assert.Nil(t, portMap, "Webhook overwrote user-defined TPU_PROCESS_PORT")
+			}
+
+			// Validate Megascale / multi-slice logic
+			if tc.isMultiSlice {
+				megascalePortMap := findContainerEnvPatch("MEGASCALE_PORT")
+				assert.NotNil(t, megascalePortMap, "MEGASCALE_PORT patch missing")
+				assert.Equal(t, tc.expectedMegascalePort, megascalePortMap["value"])
+
+				coordMap := findContainerEnvPatch("MEGASCALE_COORDINATOR_ADDRESS")
+				assert.NotNil(t, coordMap, "MEGASCALE_COORDINATOR_ADDRESS patch missing")
+				assert.Equal(t, tc.expectedMegascaleCoord, coordMap["value"])
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR updates the KubeRay TPU webhook to support Google Cloud's latest generation of TPU (Ironwood/v7x).

TPU v7x introduces a dual-chiplet architecture where a standard 4-chip VM spans two distinct NUMA nodes. To optimize memory bandwidth and avoid cross-NUMA latency, v7x workloads can now run as multiple NUMA-aligned containers within a single Pod.

This PR updates the webhook to handle multi-container TPU initialization, network addressing, and MEGASCALE orchestration without breaking legacy single-container behavior.

The new/updated env vars that are injected are:
- `TPU_PROCESS_ADDRESSES`: New env var consisting of comma-separated list of host:port pairs for all containers in the slice. This env var replaces `TPU_WORKER_HOSTNAMES` for v7x. We continue to set the legacy `TPU_WORKER_HOSTNAMES` for parity with Jobset.
 -`TPU_PROCESS_PORT`:  New env var with unique network port for the container process. The base port defaults to 8471 (can be overridden by user) and is offset by the container index. This is the same port JobSet sets.
- `TPU_WORKER_ID`: Now unique per container rather than per Pod ((PodIndex * NumContainers) + ContainerIndex).
- `MEGASCALE_PORT`: Now dynamically offset per container. Base port is 8081 (can also be set by user) and then offset by container index.
- `MEGASCALE_COORDINATOR_ADDRESS`: Now explicitly appends the base port of the 0th container (e.g. host-0:8081).

Testing Strategy:
- [x] Unit Tests
- [x] Manual Tests
  - [x] single-host (2x2x1)
  - [x] single slice, multi-host (2x2x2)
  - [x] multi slice, multi-host (2 2x2x2 slices)
  - [x] multi-container ( 2 containers each with 2 chips)