### PR TITLE
Update Dockerfile to build for multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google-go.pkg.dev/golang:1.24.2 AS builder
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.24.13 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
This PR updates the Dockerfile to correctly build for different architectures like amd64 and arm by setting `--platform` before running any `go` commands.

Tested:
- Ran Docker build

```
make docker-build
docker build . -t us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.1 
[+] Building 49.2s (14/14) FINISHED                                                                                   docker:default
 => [internal] load build definition from Dockerfile                                                                            0.1s
 => => transferring dockerfile: 659B                                                                                            0.0s
 => [internal] load metadata for gke.gcr.io/gke-distroless/static:gke_distroless_20240107.00_p0@sha256:115bea5bea0fcdf50755147  0.4s
 => [internal] load metadata for google-go.pkg.dev/golang:1.24.13                                                               2.9s
 => [internal] load .dockerignore                                                                                               0.0s
 => => transferring context: 2B                                                                                                 0.0s
 => [builder 1/6] FROM google-go.pkg.dev/golang:1.24.13@sha256:2ea380febc64f22355a66fd6141eb6575276b3ec45c97c1594f657bc47b60e  18.9s
 => => resolve google-go.pkg.dev/golang:1.24.13@sha256:2ea380febc64f22355a66fd6141eb6575276b3ec45c97c1594f657bc47b60e60         0.0s
 => => sha256:2ea380febc64f22355a66fd6141eb6575276b3ec45c97c1594f657bc47b60e60 1.61kB / 1.61kB                                  0.0s
 => => sha256:e274a5c2ba16d470b63e0826cc4bcd89005c6ebb9ca32d6b654a31708da48f9f 1.05kB / 1.05kB                                  0.0s
 => => sha256:a9682af1392c2c22c020a73ca4071cbcf70a9cb8f10aff85c9138f65a762b8b8 2.39kB / 2.39kB                                  0.0s
 => => sha256:b24cc49c86277ce21e544fa446d9eb8c9b002457d600c9ab7cb0d5e7ed269d8a 55.13MB / 55.13MB                                0.5s
 => => sha256:eee478e1a872a9c72939e9564f91285f673da80b9a40a4ef92fce4aab4b995fa 380.65MB / 380.65MB                              2.1s
 => => sha256:31faca19f21368dc883c87e456bf4dee0f93a9d428bd6447518731c2baef383d 989B / 989B                                      0.4s
 => => sha256:d48ed3858fa5251cfb1c551a521d9de616e89ba0176b47e10db5276b42b424b9 984B / 984B                                      0.7s
 => => extracting sha256:b24cc49c86277ce21e544fa446d9eb8c9b002457d600c9ab7cb0d5e7ed269d8a                                       3.4s
 => => extracting sha256:eee478e1a872a9c72939e9564f91285f673da80b9a40a4ef92fce4aab4b995fa                                      14.0s
 => => extracting sha256:31faca19f21368dc883c87e456bf4dee0f93a9d428bd6447518731c2baef383d                                       0.0s
 => => extracting sha256:d48ed3858fa5251cfb1c551a521d9de616e89ba0176b47e10db5276b42b424b9                                       0.0s
 => [internal] load build context                                                                                               0.0s
 => => transferring context: 76.28kB                                                                                            0.0s
 => CACHED [stage-1 1/2] FROM gke.gcr.io/gke-distroless/static:gke_distroless_20240107.00_p0@sha256:115bea5bea0fcdf50755147c60  0.0s
 => [builder 2/6] WORKDIR /app                                                                                                  1.3s
 => [builder 3/6] COPY go.mod go.sum ./                                                                                         0.1s
 => [builder 4/6] RUN go mod download -x                                                                                        3.1s
 => [builder 5/6] COPY main.go ./                                                                                               0.1s
 => [builder 6/6] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/kuberay-tpu-webhook .         22.2s
 => [stage-1 2/2] COPY --from=builder /go/bin/kuberay-tpu-webhook /usr/local/bin/kuberay-tpu-webhook                            0.1s
 => exporting to image                                                                                                          0.1s
 => => exporting layers                                                                                                         0.1s
 => => writing image sha256:c18282b9a004218983484110e44863eeccf556cd06a49e2ce75903ec1a97ac5d                                    0.0s
 => => naming to us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.1                                       0.0s
```