### PR TITLE
Update README and helm charts for 1.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Here's which versions of this webhook are compatible with which versions of Kube
 the bottom, the webhook version stays the same in all subsequent KubeRay versions until the next
 row's KubeRay version.
 
-| KubeRay version | webhook version |
-|-----------------|-----------------|
-| 1.4.0           | 1.2.5           |
-| 1.1.1           | 1.2.4           |
+| KubeRay version | Webhook version | TPU Generation |
+|-----------------|-----------------|-------|
+| 1.4.0           | 1.3.1           | Added Ironwood (TPU v7x) support for all configurations (multi-slice, multi-host, etc). |
+| 1.4.0           | 1.2.5           | Supports TPU versions v4 to v6e. |
+| 1.1.1           | 1.2.4           | Supports TPU versions v4 to v6e. |
 
 ## Container Images
 
@@ -52,9 +53,35 @@ Installing the webhook:
 helm install kuberay-tpu-webhook oci://us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook-helm/kuberay-tpu-webhook
 ```
 
-The above command can be edited with `-f` or `--set` flags to pass in a custom values file or key-value pair respectively for the chart (i.e. `--set tpuWebhook.image.tag=v1.2.3-gke.0`).
+The above command can be edited with `-f` or `--set` flags to pass in a custom values file or key-value pair respectively for the chart (i.e. `--set tpuWebhook.image.tag=v1.3.1-gke.2`).
 
 For common errors encountered when deploying the webhook, see the [Troubleshooting guide](https://github.com/ai-on-gke/kuberay-tpu-webhook/tree/main/Troubleshooting.md).
+
+## What the Webhook Does Automatically
+
+When you submit a RayCluster resource requesting TPUs, this mutating webhook intercepts the Pod creation and automatically injects the required configurations so that libtpu and JAX can initialize correctly. You do not need to manually configure these in your manifests. The validating webhook will accept/reject the RayCluster 
+
+* **Network Initialization:**
+    * **TPU v4 - v6e:** Automatically generates and injects the `TPU_WORKER_HOSTNAMES` list for multi-host networking.
+    * **TPU v7x (Ironwood):** Automatically generates and injects the new `TPU_PROCESS_ADDRESSES` and `TPU_PROCESS_PORT` required for v7x architecture. `TPU_PROCESS_ADDRESSES` is identical to `TPU_WORKER_HOSTNAMES`, but with the container port appended for each address.
+* **Worker Identification:** Calculates and injects `TPU_WORKER_ID` and `TPU_NAME` (a unique identifier for the replica group) for multi-host and multi-container coordination.
+* **Multi-Container (NUMA) Support:** Natively supports v7x Pods that run multiple NUMA-aligned containers, assigning unique ports and IDs to each ML process. It's important to note that multi-node support per Pod with KubeRay is experimental.
+* **Megascale (Multi-Slice) Support:** If `MEGASCALE_NUM_SLICES` is set explicitly in the Pod spec of your Ray container, the webhook automatically calculates and injects `MEGASCALE_SLICE_ID`, `MEGASCALE_COORDINATOR_ADDRESS`, and `MEGASCALE_PORT`. If utilizing the [JaxTrainer](https://docs.ray.io/en/latest/train/api/doc/ray.train.v2.jax.JaxTrainer.html#ray.train.v2.jax.JaxTrainer) in Ray Train, `MEGASCALE_NUM_SLICES` and related env vars are calculated for you based on the value of `num_workers`, `accelerator_type`, and `topology` and set automatically at runtime.
+* **Device Plugin Routing:** Injects `TPU_DEVICE_PLUGIN_HOST_IP` and `TPU_DEVICE_PLUGIN_ADDR` to ensure the container communicates with the correct node-level hardware plugin. These environment variables are utilized in Ray to scrape per-node metrics like Tensor Core utilization, HBM utilization, TPU duty cycle, and memory usage which are then viewable on the Ray Dashboard. See [View TPU metrics on the Ray Dashboard](https://docs.cloud.google.com/kubernetes-engine/docs/add-on/ray-on-gke/how-to/view-tpu-metrics).
+
+## Validating Webhook Rules
+
+In addition to automatically injecting environment variables, the webhook also acts as a validating admission controller. It analyzes your `RayCluster` custom resource upon submission and will reject the creation of the cluster if the configurations of your TPU worker groups are invalid.
+
+The webhook evaluates each `workerGroupSpec` against the following rules:
+
+* **Non-TPU Workloads are Ignored:** If a worker group's containers do not request `google.com/tpu` resources, the webhook immediately admits them without further checks.
+* **Missing NumOfHosts:** If `numOfHosts` is set to `0` or omitted for a TPU multi-host worker group (determined from the topology and accelerator type), the cluster is rejected. `numOfHosts` defaults to `1` in KubeRay.
+* **Missing Node Selectors or TPU Limits:** If a TPU worker group is missing the `cloud.google.com/gke-tpu-topology` node selector, or if the containers do not explicitly define a `google.com/tpu` resource request/limit, the cluster is rejected.
+* **Strict Topology Validation:** The webhook strictly enforces that the number of physical TPU hosts requested matches your requested physical topology. It calculates this using the following formula:
+    * **Expected Hosts:** `max(Total Chips / Chips Per Host, 1)`
+    * If the calculated `Expected Hosts` does not exactly match the `numOfHosts` defined in your `workerGroupSpec`, the cluster is rejected with the error: `"Number of workers in worker group not equal to specified topology"`.
+  * **Example:** If your node selector specifies a `2x2x2` topology (8 total chips) and your container requests `4` TPUs (`google.com/tpu: "4"`), your `numOfHosts` must be set to `2`.
 
 ## Install the KubeRay TPU Webhook from Source
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ For common errors encountered when deploying the webhook, see the [Troubleshooti
 
 ## What the Webhook Does Automatically
 
-When you submit a RayCluster resource requesting TPUs, this mutating webhook intercepts the Pod creation and automatically injects the required configurations so that libtpu and JAX can initialize correctly. You do not need to manually configure these in your manifests. The validating webhook will accept/reject the RayCluster 
+When you submit a RayCluster resource requesting TPUs, this mutating webhook intercepts the Pod creation and automatically injects the required configurations so that libtpu and JAX can initialize correctly. You do not need to manually configure these in your manifests.
 
 * **Network Initialization:**
-    * **TPU v4 - v6e:** Automatically generates and injects the `TPU_WORKER_HOSTNAMES` list for multi-host networking.
-    * **TPU v7x (Ironwood):** Automatically generates and injects the new `TPU_PROCESS_ADDRESSES` and `TPU_PROCESS_PORT` required for v7x architecture. `TPU_PROCESS_ADDRESSES` is identical to `TPU_WORKER_HOSTNAMES`, but with the container port appended for each address.
+    * **TPU v4 - v6e:** Automatically generates and injects the `TPU_WORKER_HOSTNAMES` list for multi-host networking. The webhook also sets the `subdomain` and `hostname` fields in the Pod spec.
+    * **TPU v7x (Ironwood):** In addition to the vars and fields injected in previous versions, also automatically generates and injects the new `TPU_PROCESS_ADDRESSES` and `TPU_PROCESS_PORT` required for v7x architecture. `TPU_PROCESS_ADDRESSES` is identical to `TPU_WORKER_HOSTNAMES`, but with the container port appended for each address.
 * **Worker Identification:** Calculates and injects `TPU_WORKER_ID` and `TPU_NAME` (a unique identifier for the replica group) for multi-host and multi-container coordination.
 * **Multi-Container (NUMA) Support:** Natively supports v7x Pods that run multiple NUMA-aligned containers, assigning unique ports and IDs to each ML process. It's important to note that multi-node support per Pod with KubeRay is experimental.
 * **Megascale (Multi-Slice) Support:** If `MEGASCALE_NUM_SLICES` is set explicitly in the Pod spec of your Ray container, the webhook automatically calculates and injects `MEGASCALE_SLICE_ID`, `MEGASCALE_COORDINATOR_ADDRESS`, and `MEGASCALE_PORT`. If utilizing the [JaxTrainer](https://docs.ray.io/en/latest/train/api/doc/ray.train.v2.jax.JaxTrainer.html#ray.train.v2.jax.JaxTrainer) in Ray Train, `MEGASCALE_NUM_SLICES` and related env vars are calculated for you based on the value of `num_workers`, `accelerator_type`, and `topology` and set automatically at runtime.
@@ -77,7 +77,7 @@ The webhook evaluates each `workerGroupSpec` against the following rules:
 
 * **Non-TPU Workloads are Ignored:** If a worker group's containers do not request `google.com/tpu` resources, the webhook immediately admits them without further checks.
 * **Missing NumOfHosts:** If `numOfHosts` is set to `0` or omitted for a TPU multi-host worker group (determined from the topology and accelerator type), the cluster is rejected. `numOfHosts` defaults to `1` in KubeRay.
-* **Missing Node Selectors or TPU Limits:** If a TPU worker group is missing the `cloud.google.com/gke-tpu-topology` node selector, or if the containers do not explicitly define a `google.com/tpu` resource request/limit, the cluster is rejected.
+* **Missing Node Selectors:** If a TPU worker group is missing the `cloud.google.com/gke-tpu-topology` node selector the cluster is rejected.
 * **Strict Topology Validation:** The webhook strictly enforces that the number of physical TPU hosts requested matches your requested physical topology. It calculates this using the following formula:
     * **Expected Hosts:** `max(Total Chips / Chips Per Host, 1)`
     * If the calculated `Expected Hosts` does not exactly match the `numOfHosts` defined in your `workerGroupSpec`, the cluster is rejected with the error: `"Number of workers in worker group not equal to specified topology"`.

--- a/deployments/deployment.yaml
+++ b/deployments/deployment.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       serviceAccountName: kuberay-tpu-webhook
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.1@sha256:e2c6cfa375ad75eb08aa32ef5136c1500bc7def5a8ee252b16f6b3c681f5b6b6
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.1-gke.2@sha256:c392f614b7ffc2071a46b5fa7c1ea309475265be5af806927bb4f87313d9ca43
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.5"
+appVersion: "1.3.1"

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -8,7 +8,7 @@ tpuWebhook:
   
   image:
     repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
-    tag: v1.2.5-gke.1
+    tag: v1.3.1-gke.2
     pullPolicy: IfNotPresent
 
   deployment:


### PR DESCRIPTION
This PR updates the default version to the latest recommended version (v1.3.1) which supports Ironwood TPU. This PR also updates the README to be more descriptive, include information on multi-slice, and outline changes related to Ironwood.