### PR TITLE
Update security violation for imagefreshness to latest image

### DIFF
--- a/security_test/allowlist/category/helm/imagefreshness.json
+++ b/security_test/allowlist/category/helm/imagefreshness.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "kuberay-tpu-webhook",
-      "image": "us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.1-gke.2"
+      "image": "us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.4-gke.0"
     },
-    "message": "container \"kuberay-tpu-webhook\" in Deployment \"kuberay-tpu-webhook\" has an image \"us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.1-gke.2\" that does not have a valid digest.",
+    "message": "container \"kuberay-tpu-webhook\" in Deployment \"kuberay-tpu-webhook\" has an image \"us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.4-gke.0\" that does not have a valid digest.",
     "policyName": "imagefreshness",
     "resourceKey": {
       "group": "apps",

--- a/security_test/allowlist/category/helm/imagefreshness.json
+++ b/security_test/allowlist/category/helm/imagefreshness.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "kuberay-tpu-webhook",
-      "image": "us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.1"
+      "image": "us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.1-gke.2"
     },
-    "message": "container \"kuberay-tpu-webhook\" in Deployment \"kuberay-tpu-webhook\" has an image \"us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.5-gke.1\" that does not have a valid digest.",
+    "message": "container \"kuberay-tpu-webhook\" in Deployment \"kuberay-tpu-webhook\" has an image \"us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.3.1-gke.2\" that does not have a valid digest.",
     "policyName": "imagefreshness",
     "resourceKey": {
       "group": "apps",


### PR DESCRIPTION
This PR relates to https://github.com/ai-on-gke/quick-start-guides/pull/30, we still want to keep the `imagefreshness` violation because it's possible the image may not be updated for 6+ months and still be valid. This is an OSS tool in a stable state, but is only updated on an as-needed basis for changes in new TPU generations.