### PR TITLE
Fix Pod Affinity rules with KubeRay MultiHostIndexing feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ const (
 	megascalePortBase  = 8081
 	tpuResourceName    = corev1.ResourceName("google.com/tpu")
 	tpu7xType          = "tpu7x"
+
+	legacyReplicaIndexLabelKey = "replicaIndex"
 )
 
 var (
@@ -332,7 +334,7 @@ func injectReplicaLabel(clusterName string, namespace string, replicaIndex int, 
 	labelPath := "/metadata/labels/replicaIndex"
 	replicaLabelValue := fmt.Sprintf("%s-%d", workerGroupName, replicaIndex)
 
-	klog.V(1).InfoS("injectReplicaLabel", "RayCluster", namespace+"/"+clusterName, "replicaIndex", replicaLabelValue)
+	klog.V(1).InfoS("injectReplicaLabel", "RayCluster", namespace+"/"+clusterName, legacyReplicaIndexLabelKey, replicaLabelValue)
 
 	labelPatch["path"] = labelPath
 	labelPatch["value"] = replicaLabelValue
@@ -368,7 +370,7 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 		affinityLabelKey = utils.RayWorkerReplicaIndexKey
 		affinityLabelValue = fmt.Sprint(replicaIndex)
 	} else {
-		affinityLabelKey = "replicaIndex"
+		affinityLabelKey = legacyReplicaIndexLabelKey
 		affinityLabelValue = fmt.Sprintf("%s-%d", workerGroupName, replicaIndex)
 	}
 
@@ -607,7 +609,7 @@ func getNextWorkerID(sliceToTPUHosts map[slice][]int, podSlice slice, namespace 
 		lastID = workerID
 		tpuWorkerID++
 	}
-	klog.V(1).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "Worker Group", podSlice.groupName, "replicaIndex", replicaIndex, "TPU_WORKER_ID", tpuWorkerID)
+	klog.V(1).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "Worker Group", podSlice.groupName, legacyReplicaIndexLabelKey, replicaIndex, "TPU_WORKER_ID", tpuWorkerID)
 	return tpuWorkerID, nil
 }
 
@@ -640,7 +642,7 @@ func (t *TPUWebhookServer) getSliceToTPUHosts(clusterName string, groupName stri
 			// Pod does not request TPUs, 'ray.io/group' is not a TPU worker group
 			return sliceToTPUHosts, nil
 		}
-		replicaIndexLabel := existingPod.Labels["replicaIndex"]
+		replicaIndexLabel := existingPod.Labels[legacyReplicaIndexLabelKey]
 		if replicaIndexLabel == "" {
 			// Pod has not been intercepted by the KubeRay TPU webhook yet
 			continue
@@ -684,7 +686,7 @@ func (t *TPUWebhookServer) getSliceToTPUHosts(clusterName string, groupName stri
 			} else {
 				sliceToTPUHosts[podSlice] = append(sliceToTPUHosts[podSlice], hostIndex)
 			}
-			klog.V(1).InfoS("getSliceToTPUHosts", "RayCluster", namespace+"/"+clusterName, "ReplicaIndex", existingReplicaIndex, "HostIndex", hostIndex)
+			klog.V(1).InfoS("getSliceToTPUHosts", "RayCluster", namespace+"/"+clusterName, legacyReplicaIndexLabelKey, existingReplicaIndex, "HostIndex", hostIndex)
 		}
 	}
 	return sliceToTPUHosts, nil
@@ -1091,7 +1093,7 @@ func (t *TPUWebhookServer) isLastAdmittedPod(pod *corev1.Pod) (bool, error) {
 		// Pod does not use TPUs
 		return false, nil
 	}
-	replicaIndex := pod.Labels["replicaIndex"]
+	replicaIndex := pod.Labels[legacyReplicaIndexLabelKey]
 	if replicaIndex == "" {
 		// Pod was not mutated by the webhook
 		return false, nil

--- a/main.go
+++ b/main.go
@@ -355,7 +355,7 @@ func makeLabelSelectorRequirement(key string, op metav1.LabelSelectorOperator, v
 // injectAffinity injects pod affinity and anti-affinity scheduling constraints using replicaIndex and cluster labels
 // to ensure TPU Pods from the same multi-host replica are co-located.
 func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, patches *[]patch) {
-	clusterName := pod.Labels["ray.io/cluster"]
+	clusterName := pod.Labels[utils.RayClusterLabelKey]
 	topologyKey := "cloud.google.com/gke-nodepool"
 
 	var affinityLabelKey string
@@ -376,8 +376,8 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 
 	// Co-schedule on a node-pool Pods with the same replica index, RayCluster, and worker group label
 	replicaIndexIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpIn, affinityLabelValue)
-	clusterIn := makeLabelSelectorRequirement("ray.io/cluster", metav1.LabelSelectorOpIn, clusterName)
-	groupIn := makeLabelSelectorRequirement("ray.io/group", metav1.LabelSelectorOpIn, workerGroupName)
+	clusterIn := makeLabelSelectorRequirement(utils.RayClusterLabelKey, metav1.LabelSelectorOpIn, clusterName)
+	groupIn := makeLabelSelectorRequirement(utils.RayNodeGroupLabelKey, metav1.LabelSelectorOpIn, workerGroupName)
 	podAffinity := corev1.PodAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
 			LabelSelector: &metav1.LabelSelector{
@@ -388,8 +388,8 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 	}
 	// Avoid scheduling on a node-pool with Pods of a different worker group or RayCluster and ANY replicaIndex label
 	replicaIndexNotIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpNotIn, affinityLabelValue)
-	clusterNotIn := makeLabelSelectorRequirement("ray.io/cluster", metav1.LabelSelectorOpNotIn, clusterName)
-	groupNotIn := makeLabelSelectorRequirement("ray.io/group", metav1.LabelSelectorOpNotIn, workerGroupName)
+	clusterNotIn := makeLabelSelectorRequirement(utils.RayClusterLabelKey, metav1.LabelSelectorOpNotIn, clusterName)
+	groupNotIn := makeLabelSelectorRequirement(utils.RayNodeGroupLabelKey, metav1.LabelSelectorOpNotIn, workerGroupName)
 	replicaIndexExists := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpExists)
 	podAntiAffinity := corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -618,7 +618,7 @@ func (t *TPUWebhookServer) getSliceToTPUHosts(clusterName string, groupName stri
 	sliceToTPUHosts := make(map[slice][]int)
 
 	// we only care about workers in the same RayCluster and worker group when assigning IDs
-	podsInGroup, err := t.podLister.Pods(namespace).List(labels.SelectorFromSet(labels.Set{"ray.io/cluster": clusterName, "ray.io/group": groupName}))
+	podsInGroup, err := t.podLister.Pods(namespace).List(labels.SelectorFromSet(labels.Set{utils.RayClusterLabelKey: clusterName, utils.RayNodeGroupLabelKey: groupName}))
 	if err != nil {
 		return nil, err
 	}
@@ -765,11 +765,11 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 
 	// ray operator only sets GenerateName field - doesn't include random suffix until after admission request
 	// use mapping of {cluster name, group name, replicaIndex} -> workers to extract next TPU_WORKER_ID
-	clusterName := pod.Labels["ray.io/cluster"]
+	clusterName := pod.Labels[utils.RayClusterLabelKey]
 	if clusterName == "" {
 		return nil, errors.New("Ray Pod created by KubeRay missing RayCluster label")
 	}
-	groupName := pod.Labels["ray.io/group"]
+	groupName := pod.Labels[utils.RayNodeGroupLabelKey]
 	if groupName == "" {
 		return nil, errors.New("Ray Pod created by KubeRay missing Group label")
 	}
@@ -1098,7 +1098,7 @@ func (t *TPUWebhookServer) isLastAdmittedPod(pod *corev1.Pod) (bool, error) {
 		// Pod was not mutated by the webhook
 		return false, nil
 	}
-	clusterName := pod.Labels["ray.io/cluster"]
+	clusterName := pod.Labels[utils.RayClusterLabelKey]
 	if clusterName == "" {
 		return false, errors.New("Ray Pod created by KubeRay missing RayCluster label")
 	}

--- a/main.go
+++ b/main.go
@@ -354,27 +354,45 @@ func makeLabelSelectorRequirement(key string, op metav1.LabelSelectorOperator, v
 // to ensure TPU Pods from the same multi-host replica are co-located.
 func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, patches *[]patch) {
 	clusterName := pod.Labels["ray.io/cluster"]
-	replicaIndexLabel := fmt.Sprintf("%s-%d", workerGroupName, replicaIndex)
 	topologyKey := "cloud.google.com/gke-nodepool"
 
-	// Co-schedule on a node-pool Pods with the same replicaIndex and RayCluster label
-	replicaIndexIn := makeLabelSelectorRequirement("replicaIndex", metav1.LabelSelectorOpIn, replicaIndexLabel)
+	var affinityLabelKey string
+	var affinityLabelValue string
+
+	// Check if the Pod has native KubeRay indexing labels
+	_, hasReplicaLabel := pod.Labels[utils.RayWorkerReplicaIndexKey]
+	_, hasHostLabel := pod.Labels[utils.RayHostIndexKey]
+
+	// Determine the label to use for affinity, set either by KubeRay or this webhook.
+	if hasReplicaLabel && hasHostLabel {
+		affinityLabelKey = utils.RayWorkerReplicaIndexKey
+		affinityLabelValue = fmt.Sprint(replicaIndex)
+	} else {
+		affinityLabelKey = "replicaIndex"
+		affinityLabelValue = fmt.Sprintf("%s-%d", workerGroupName, replicaIndex)
+	}
+
+	// Co-schedule on a node-pool Pods with the same replica index, RayCluster, and worker group label
+	replicaIndexIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpIn, affinityLabelValue)
 	clusterIn := makeLabelSelectorRequirement("ray.io/cluster", metav1.LabelSelectorOpIn, clusterName)
+	groupIn := makeLabelSelectorRequirement("ray.io/group", metav1.LabelSelectorOpIn, workerGroupName)
 	podAffinity := corev1.PodAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
 			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{replicaIndexIn, clusterIn},
+				MatchExpressions: []metav1.LabelSelectorRequirement{replicaIndexIn, clusterIn, groupIn},
 			},
 			TopologyKey: topologyKey,
 		}},
 	}
-	// Avoid scheduling on a node-pool with Pods of a different RayCluster and ANY replicaIndex label
-	replicaIndexNotIn := makeLabelSelectorRequirement("replicaIndex", metav1.LabelSelectorOpNotIn, replicaIndexLabel)
+	// Avoid scheduling on a node-pool with Pods of a different worker group or RayCluster and ANY replicaIndex label
+	replicaIndexNotIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpNotIn, affinityLabelValue)
 	clusterNotIn := makeLabelSelectorRequirement("ray.io/cluster", metav1.LabelSelectorOpNotIn, clusterName)
-	replicaIndexExists := makeLabelSelectorRequirement("replicaIndex", metav1.LabelSelectorOpExists)
+	groupNotIn := makeLabelSelectorRequirement("ray.io/group", metav1.LabelSelectorOpNotIn, workerGroupName)
+	replicaIndexExists := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpExists)
 	podAntiAffinity := corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 			{
+				// Repel pods in the same cluster that have a different replica index.
 				LabelSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						replicaIndexNotIn,
@@ -384,6 +402,18 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 				TopologyKey: topologyKey,
 			},
 			{
+				// Repel pods in the same cluster that belong to a different worker group.
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						groupNotIn,
+						clusterIn,
+						replicaIndexExists,
+					},
+				},
+				TopologyKey: topologyKey,
+			},
+			{
+				// Repel Pods from different RayClusters from scheduling to this node pool.
 				LabelSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						clusterNotIn,

--- a/main.go
+++ b/main.go
@@ -362,54 +362,43 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 	var affinityLabelValue string
 
 	// Check if the Pod has native KubeRay indexing labels
-	_, hasReplicaLabel := pod.Labels[utils.RayWorkerReplicaIndexKey]
+	replicaName, hasReplicaNameLabel := pod.Labels[utils.RayWorkerReplicaNameKey]
 	_, hasHostLabel := pod.Labels[utils.RayHostIndexKey]
 
 	// Determine the label to use for affinity, set either by KubeRay or this webhook.
-	if hasReplicaLabel && hasHostLabel {
-		affinityLabelKey = utils.RayWorkerReplicaIndexKey
-		affinityLabelValue = fmt.Sprint(replicaIndex)
+	if hasReplicaNameLabel && hasHostLabel {
+		// Use the unique replica name (e.g. ray.io/worker-group-replica-name: workergroup-xh3hf) for scheduling constraints
+		affinityLabelKey = utils.RayWorkerReplicaNameKey
+		affinityLabelValue = replicaName
 	} else {
+		// Fallback to legacy webhook label (e.g. replicaIndex: workergroup-0)
 		affinityLabelKey = legacyReplicaIndexLabelKey
 		affinityLabelValue = fmt.Sprintf("%s-%d", workerGroupName, replicaIndex)
 	}
 
-	// Co-schedule on a node-pool Pods with the same replica index, RayCluster, and worker group label
-	replicaIndexIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpIn, affinityLabelValue)
+	// Co-schedule on a node-pool Pods with the same unique replica name and RayCluster
+	replicaIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpIn, affinityLabelValue)
 	clusterIn := makeLabelSelectorRequirement(utils.RayClusterLabelKey, metav1.LabelSelectorOpIn, clusterName)
-	groupIn := makeLabelSelectorRequirement(utils.RayNodeGroupLabelKey, metav1.LabelSelectorOpIn, workerGroupName)
 	podAffinity := corev1.PodAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
 			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{replicaIndexIn, clusterIn, groupIn},
+				MatchExpressions: []metav1.LabelSelectorRequirement{replicaIn, clusterIn},
 			},
 			TopologyKey: topologyKey,
 		}},
 	}
-	// Avoid scheduling on a node-pool with Pods of a different worker group or RayCluster and ANY replicaIndex label
-	replicaIndexNotIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpNotIn, affinityLabelValue)
+	// Avoid scheduling on a node-pool with Pods of a different replica name label
+	replicaNotIn := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpNotIn, affinityLabelValue)
 	clusterNotIn := makeLabelSelectorRequirement(utils.RayClusterLabelKey, metav1.LabelSelectorOpNotIn, clusterName)
-	groupNotIn := makeLabelSelectorRequirement(utils.RayNodeGroupLabelKey, metav1.LabelSelectorOpNotIn, workerGroupName)
-	replicaIndexExists := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpExists)
+	replicaExists := makeLabelSelectorRequirement(affinityLabelKey, metav1.LabelSelectorOpExists)
 	podAntiAffinity := corev1.PodAntiAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 			{
 				// Repel pods in the same cluster that have a different replica index.
 				LabelSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
-						replicaIndexNotIn,
+						replicaNotIn,
 						clusterIn,
-					},
-				},
-				TopologyKey: topologyKey,
-			},
-			{
-				// Repel pods in the same cluster that belong to a different worker group.
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						groupNotIn,
-						clusterIn,
-						replicaIndexExists,
 					},
 				},
 				TopologyKey: topologyKey,
@@ -419,7 +408,7 @@ func injectAffinity(pod *corev1.Pod, replicaIndex int, workerGroupName string, p
 				LabelSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						clusterNotIn,
-						replicaIndexExists,
+						replicaExists,
 					},
 				},
 				TopologyKey: topologyKey,

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -207,7 +207,7 @@ func getTestInterceptedTPUPods(templatePod *corev1.Pod, numPods int, numSlices i
 		}
 		testTPUWorkerCopy.Spec.Containers[0].Env = env
 		testTPUWorkerCopy.Name = fmt.Sprintf("%s-%d", "intercepted-tpu-pod", i)
-		testTPUWorkerCopy.Labels["replicaIndex"] = replicaIndex
+		testTPUWorkerCopy.Labels[legacyReplicaIndexLabelKey] = replicaIndex
 		testInterceptedTPUPods = append(testInterceptedTPUPods, testTPUWorkerCopy)
 	}
 	return testInterceptedTPUPods
@@ -983,7 +983,7 @@ func Test_InjectAffinity(t *testing.T) {
 			testPod:              getTestTPUWorker("test-cluster", "test-group-name", "test-namespace", "tpu-v4-podslice", "2x2x1", "4"),
 			replicaIndex:         0,
 			groupName:            "test-group-name",
-			expectedLabelKey:     "replicaIndex",
+			expectedLabelKey:     legacyReplicaIndexLabelKey,
 			expectedLabelValue:   "test-group-name-0",
 			expectedClusterLabel: "test-cluster",
 		},
@@ -1433,7 +1433,7 @@ func Test_IsLastAdmittedPod(t *testing.T) {
 			// set TPU_WORKER_ID for testPod
 			if containerRequestingTPUs(tc.testPod.Spec.Containers...) {
 				if tc.testReplicaID != "" {
-					tc.testPod.Labels["replicaIndex"] = tc.testReplicaID
+					tc.testPod.Labels[legacyReplicaIndexLabelKey] = tc.testReplicaID
 					tc.testPod.Spec.Containers[0].Env = []corev1.EnvVar{
 						{
 							Name:  "TPU_WORKER_ID",

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1016,10 +1016,10 @@ func Test_InjectAffinity(t *testing.T) {
 			}
 			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[tc.expectedLabelKey].Operator)
 			assert.Equal(t, []string{tc.expectedLabelValue}, podMatchExprs[tc.expectedLabelKey].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs["ray.io/cluster"].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, podMatchExprs["ray.io/cluster"].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs["ray.io/group"].Operator)
-			assert.Equal(t, []string{tc.groupName}, podMatchExprs["ray.io/group"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[utils.RayClusterLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, podMatchExprs[utils.RayClusterLabelKey].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[utils.RayNodeGroupLabelKey].Operator)
+			assert.Equal(t, []string{tc.groupName}, podMatchExprs[utils.RayNodeGroupLabelKey].Values)
 
 			// Validate PodAntiAffinity is injected with expected label selectors
 			podAntiAffinityTerms := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
@@ -1032,18 +1032,18 @@ func Test_InjectAffinity(t *testing.T) {
 			}
 			assert.Equal(t, metav1.LabelSelectorOpNotIn, term0MatchExprs[tc.expectedLabelKey].Operator)
 			assert.Equal(t, []string{tc.expectedLabelValue}, term0MatchExprs[tc.expectedLabelKey].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, term0MatchExprs["ray.io/cluster"].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, term0MatchExprs["ray.io/cluster"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, term0MatchExprs[utils.RayClusterLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, term0MatchExprs[utils.RayClusterLabelKey].Values)
 
 			// Anti-affinity for Pods of same cluster but different group
 			term1MatchExprs := map[string]metav1.LabelSelectorRequirement{}
 			for _, expr := range podAntiAffinityTerms[1].LabelSelector.MatchExpressions {
 				term1MatchExprs[expr.Key] = expr
 			}
-			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs["ray.io/group"].Operator)
-			assert.Equal(t, []string{tc.groupName}, term1MatchExprs["ray.io/group"].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs["ray.io/cluster"].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs["ray.io/cluster"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs[utils.RayNodeGroupLabelKey].Operator)
+			assert.Equal(t, []string{tc.groupName}, term1MatchExprs[utils.RayNodeGroupLabelKey].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs[utils.RayClusterLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs[utils.RayClusterLabelKey].Values)
 			assert.Equal(t, metav1.LabelSelectorOpExists, term1MatchExprs[tc.expectedLabelKey].Operator)
 
 			// Anti-affinity for Pods of different cluster when replicaIndex exists
@@ -1052,8 +1052,8 @@ func Test_InjectAffinity(t *testing.T) {
 				term2MatchExprs[expr.Key] = expr
 			}
 			assert.Equal(t, metav1.LabelSelectorOpExists, term2MatchExprs[tc.expectedLabelKey].Operator)
-			assert.Equal(t, metav1.LabelSelectorOpNotIn, term2MatchExprs["ray.io/cluster"].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, term2MatchExprs["ray.io/cluster"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpNotIn, term2MatchExprs[utils.RayClusterLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, term2MatchExprs[utils.RayClusterLabelKey].Values)
 			assert.NotNil(t, podAntiAffinityTerms[2].NamespaceSelector)
 		})
 	}

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -970,6 +970,7 @@ func Test_InjectAffinity(t *testing.T) {
 	nativePod := getTestTPUWorker("test-cluster", "test-group-name", "test-namespace", "tpu-v4-podslice", "2x2x1", "4")
 	nativePod.Labels[utils.RayWorkerReplicaIndexKey] = "0"
 	nativePod.Labels[utils.RayHostIndexKey] = "0"
+	nativePod.Labels[utils.RayWorkerReplicaNameKey] = "test-group-name-xh3hf"
 
 	tests := map[string]struct {
 		testPod              *corev1.Pod
@@ -991,8 +992,8 @@ func Test_InjectAffinity(t *testing.T) {
 			testPod:              nativePod,
 			replicaIndex:         0,
 			groupName:            "test-group-name",
-			expectedLabelKey:     utils.RayWorkerReplicaIndexKey,
-			expectedLabelValue:   "0",
+			expectedLabelKey:     utils.RayWorkerReplicaNameKey,
+			expectedLabelValue:   "test-group-name-xh3hf",
 			expectedClusterLabel: "test-cluster",
 		},
 	}
@@ -1018,14 +1019,12 @@ func Test_InjectAffinity(t *testing.T) {
 			assert.Equal(t, []string{tc.expectedLabelValue}, podMatchExprs[tc.expectedLabelKey].Values)
 			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[utils.RayClusterLabelKey].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, podMatchExprs[utils.RayClusterLabelKey].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[utils.RayNodeGroupLabelKey].Operator)
-			assert.Equal(t, []string{tc.groupName}, podMatchExprs[utils.RayNodeGroupLabelKey].Values)
 
 			// Validate PodAntiAffinity is injected with expected label selectors
 			podAntiAffinityTerms := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			assert.Len(t, podAntiAffinityTerms, 3, "Expected exactly 3 anti-affinity terms")
+			assert.Len(t, podAntiAffinityTerms, 2, "Expected exactly 2 anti-affinity terms")
 
-			// Anti-affinity for Pods of same cluster but different replicaIndex
+			// Anti-affinity for Pods of same cluster but different replica name/index
 			term0MatchExprs := map[string]metav1.LabelSelectorRequirement{}
 			for _, expr := range podAntiAffinityTerms[0].LabelSelector.MatchExpressions {
 				term0MatchExprs[expr.Key] = expr
@@ -1035,26 +1034,15 @@ func Test_InjectAffinity(t *testing.T) {
 			assert.Equal(t, metav1.LabelSelectorOpIn, term0MatchExprs[utils.RayClusterLabelKey].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term0MatchExprs[utils.RayClusterLabelKey].Values)
 
-			// Anti-affinity for Pods of same cluster but different group
+			// Anti-affinity for Pods of different cluster when replica name/index exists
 			term1MatchExprs := map[string]metav1.LabelSelectorRequirement{}
 			for _, expr := range podAntiAffinityTerms[1].LabelSelector.MatchExpressions {
 				term1MatchExprs[expr.Key] = expr
 			}
-			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs[utils.RayNodeGroupLabelKey].Operator)
-			assert.Equal(t, []string{tc.groupName}, term1MatchExprs[utils.RayNodeGroupLabelKey].Values)
-			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs[utils.RayClusterLabelKey].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs[utils.RayClusterLabelKey].Values)
 			assert.Equal(t, metav1.LabelSelectorOpExists, term1MatchExprs[tc.expectedLabelKey].Operator)
-
-			// Anti-affinity for Pods of different cluster when replicaIndex exists
-			term2MatchExprs := map[string]metav1.LabelSelectorRequirement{}
-			for _, expr := range podAntiAffinityTerms[2].LabelSelector.MatchExpressions {
-				term2MatchExprs[expr.Key] = expr
-			}
-			assert.Equal(t, metav1.LabelSelectorOpExists, term2MatchExprs[tc.expectedLabelKey].Operator)
-			assert.Equal(t, metav1.LabelSelectorOpNotIn, term2MatchExprs[utils.RayClusterLabelKey].Operator)
-			assert.Equal(t, []string{tc.expectedClusterLabel}, term2MatchExprs[utils.RayClusterLabelKey].Values)
-			assert.NotNil(t, podAntiAffinityTerms[2].NamespaceSelector)
+			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs[utils.RayClusterLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs[utils.RayClusterLabelKey].Values)
+			assert.NotNil(t, podAntiAffinityTerms[1].NamespaceSelector)
 		})
 	}
 }

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -966,18 +966,33 @@ func Test_InjectReplicaLabel(t *testing.T) {
 }
 
 func Test_InjectAffinity(t *testing.T) {
+	// Prepare a pod with native KubeRay indexing labels
+	nativePod := getTestTPUWorker("test-cluster", "test-group-name", "test-namespace", "tpu-v4-podslice", "2x2x1", "4")
+	nativePod.Labels[utils.RayWorkerReplicaIndexKey] = "0"
+	nativePod.Labels[utils.RayHostIndexKey] = "0"
+
 	tests := map[string]struct {
 		testPod              *corev1.Pod
 		replicaIndex         int
 		groupName            string
-		expectedReplicaLabel string
+		expectedLabelKey     string
+		expectedLabelValue   string
 		expectedClusterLabel string
 	}{
-		"injectAffinity with replicaIndex and cluster labels": {
-			testPod:              getTestTPUWorker("test-cluster", "test-group", "test-namespace", "tpu-v4-podslice", "2x2x1", "4"),
+		"injectAffinity with legacy replicaIndex and cluster labels": {
+			testPod:              getTestTPUWorker("test-cluster", "test-group-name", "test-namespace", "tpu-v4-podslice", "2x2x1", "4"),
 			replicaIndex:         0,
 			groupName:            "test-group-name",
-			expectedReplicaLabel: "test-group-name-0",
+			expectedLabelKey:     "replicaIndex",
+			expectedLabelValue:   "test-group-name-0",
+			expectedClusterLabel: "test-cluster",
+		},
+		"injectAffinity with KubeRay native labels": {
+			testPod:              nativePod,
+			replicaIndex:         0,
+			groupName:            "test-group-name",
+			expectedLabelKey:     utils.RayWorkerReplicaIndexKey,
+			expectedLabelValue:   "0",
 			expectedClusterLabel: "test-cluster",
 		},
 	}
@@ -999,32 +1014,47 @@ func Test_InjectAffinity(t *testing.T) {
 			for _, expr := range podAffinityTerms[0].LabelSelector.MatchExpressions {
 				podMatchExprs[expr.Key] = expr
 			}
-			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs["replicaIndex"].Operator)
-			assert.Equal(t, []string{tc.expectedReplicaLabel}, podMatchExprs["replicaIndex"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs[tc.expectedLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedLabelValue}, podMatchExprs[tc.expectedLabelKey].Values)
 			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, podMatchExprs["ray.io/cluster"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, podMatchExprs["ray.io/group"].Operator)
+			assert.Equal(t, []string{tc.groupName}, podMatchExprs["ray.io/group"].Values)
 
 			// Validate PodAntiAffinity is injected with expected label selectors
 			podAntiAffinityTerms := affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			// Check anti-affinity for Pods of same cluster and different replicaIndex
-			term1MatchExprs := map[string]metav1.LabelSelectorRequirement{}
+			assert.Len(t, podAntiAffinityTerms, 3, "Expected exactly 3 anti-affinity terms")
+
+			// Anti-affinity for Pods of same cluster but different replicaIndex
+			term0MatchExprs := map[string]metav1.LabelSelectorRequirement{}
 			for _, expr := range podAntiAffinityTerms[0].LabelSelector.MatchExpressions {
+				term0MatchExprs[expr.Key] = expr
+			}
+			assert.Equal(t, metav1.LabelSelectorOpNotIn, term0MatchExprs[tc.expectedLabelKey].Operator)
+			assert.Equal(t, []string{tc.expectedLabelValue}, term0MatchExprs[tc.expectedLabelKey].Values)
+			assert.Equal(t, metav1.LabelSelectorOpIn, term0MatchExprs["ray.io/cluster"].Operator)
+			assert.Equal(t, []string{tc.expectedClusterLabel}, term0MatchExprs["ray.io/cluster"].Values)
+
+			// Anti-affinity for Pods of same cluster but different group
+			term1MatchExprs := map[string]metav1.LabelSelectorRequirement{}
+			for _, expr := range podAntiAffinityTerms[1].LabelSelector.MatchExpressions {
 				term1MatchExprs[expr.Key] = expr
 			}
-			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs["replicaIndex"].Operator)
-			assert.Equal(t, []string{tc.expectedReplicaLabel}, term1MatchExprs["replicaIndex"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpNotIn, term1MatchExprs["ray.io/group"].Operator)
+			assert.Equal(t, []string{tc.groupName}, term1MatchExprs["ray.io/group"].Values)
 			assert.Equal(t, metav1.LabelSelectorOpIn, term1MatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term1MatchExprs["ray.io/cluster"].Values)
+			assert.Equal(t, metav1.LabelSelectorOpExists, term1MatchExprs[tc.expectedLabelKey].Operator)
 
-			// Check anti-affinity for Pods of different cluster when replicaIndex exists
+			// Anti-affinity for Pods of different cluster when replicaIndex exists
 			term2MatchExprs := map[string]metav1.LabelSelectorRequirement{}
-			for _, expr := range podAntiAffinityTerms[1].LabelSelector.MatchExpressions {
+			for _, expr := range podAntiAffinityTerms[2].LabelSelector.MatchExpressions {
 				term2MatchExprs[expr.Key] = expr
 			}
-			assert.Equal(t, metav1.LabelSelectorOpExists, term2MatchExprs["replicaIndex"].Operator)
+			assert.Equal(t, metav1.LabelSelectorOpExists, term2MatchExprs[tc.expectedLabelKey].Operator)
 			assert.Equal(t, metav1.LabelSelectorOpNotIn, term2MatchExprs["ray.io/cluster"].Operator)
 			assert.Equal(t, []string{tc.expectedClusterLabel}, term2MatchExprs["ray.io/cluster"].Values)
-			assert.NotNil(t, podAntiAffinityTerms[1].NamespaceSelector)
+			assert.NotNil(t, podAntiAffinityTerms[2].NamespaceSelector)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where with the new native indexing labels set by KubeRay, `replicaIndex` is no longer set and the pod Affinity rules were not updated to utilize the new Pod labels. This resulted in unexpected scheduling behavior.

This PR:
- checks for the new labels and utilizes them in the label selector requirement rules if set
- adds an affinity/anti-affinity for Ray worker group, since the KubeRay index label is not unique across worker groups or RayClusters (however we still prefer using the index label versus the unique `RayWorkerReplicaName` label since we want to utilize the integer index for MEGASCALE vars)


This PR has been tested with:
- [x] Unit Tests - added new test case for the new labels
- [ ] Manual tests