### PR TITLE
[chore] Update Dockerfile for new Go dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.24.13 AS builder
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.25.8 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
This PR updates the Dockerfile builder for Go 1.25.8. This should resolve docker build errors in the image pipeline.