### PR TITLE
[chore] Bump Go version to 1.25.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.25.8 AS builder
+FROM --platform=$BUILDPLATFORM google-go.pkg.dev/golang:1.25.9 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,11 +14,11 @@
 
 steps:
   - id: 'go mod download'
-    name: 'golang:1.25.8'
+    name: 'golang:1.25.9'
     entrypoint: 'go'
     args: ['mod', 'download']
   - id: 'kuberay tpu webhook fmt'
-    name: 'golang:1.25.8'
+    name: 'golang:1.25.9'
     entrypoint: 'bash'
     args:
       - '-c'
@@ -26,7 +26,7 @@ steps:
         set -e
         make fmt
   - id: 'kuberay tpu webhook vet'
-    name: 'golang:1.25.8'
+    name: 'golang:1.25.9'
     entrypoint: 'bash'
     args:
       - '-c'
@@ -34,7 +34,7 @@ steps:
         set -e
         make vet
   - id: 'kuberay tpu webhook test'
-    name: 'golang:1.25.8'
+    name: 'golang:1.25.9'
     entrypoint: 'bash'
     args:
       - '-c'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/kuberay-tpu-webhook
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/ray-project/kuberay/ray-operator v1.5.0


### PR DESCRIPTION
This PR updates the go dependencies in the webhook to resolve CVE-2026-27143, CVE-2026-27144, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283, and CVE-2026-27140 on debian toolchain 1.25.8.