### PR TITLE
Mutate pod load test & cache control

### DIFF
--- a/main.go
+++ b/main.go
@@ -813,7 +813,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		// CRITICAL SECTION: Calculating the replica index, pod slice, and
 		// worker ID must happen one at a time with an up-to-date cache.
 		// Wait for PodInformer cache to update from previous requests.
-		t.podMutateMu.Lock()
+		timedout := t.podMutateMu.Lock(2 * time.Second)
+		if timedout {
+			klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
+		}
 
 		// query k8s client to populate sliceToTPUHosts
 		sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
@@ -1112,10 +1115,15 @@ func (t *TPUWebhookServer) addPod(obj interface{}) {
 // podSyncLocker provides a lock that allows the mutating webhook to guarantee
 // only one pod is mutated at a time and the cache is valid during requests.
 type podSyncLocker struct {
-	m            sync.Mutex
-	cond         *sync.Cond
-	synced       bool
-	lastAdmitted string
+	m      sync.Mutex
+	cond   *sync.Cond
+	synced bool
+
+	// lastAdmitted and cacheInvalidated are only valid when synced is false.
+	// lastAdmitted is the pod ID that needs to hit the informer, and
+	// cacheInvalidated is the time at which we started waiting for it.
+	lastAdmitted     string
+	cacheInvalidated time.Time
 }
 
 func newPodSyncLocker() *podSyncLocker {
@@ -1128,15 +1136,23 @@ func newPodSyncLocker() *podSyncLocker {
 
 // Lock blocks until both all callers release the lock and the cache is
 // up-to-date.
-func (c *podSyncLocker) Lock() {
+func (c *podSyncLocker) Lock(timeout time.Duration) (timedout bool) {
 	// Acquire the lock (which must be held to block on the condition) as well
 	// as to guarantee only one mutate request is in-flight.
 	// If the cache is not synced, block on the condition for it to become
 	// synced.
 	c.m.Lock()
 	for !c.synced {
+		// If it has been too long between when the cache was marked invalid and
+		// now, then bail and proceed with a stale cache.
+		if time.Now().Sub(c.cacheInvalidated) > timeout {
+			klog.V(0).Infof("Waiting for pod %q admitted at %s timed out; proceeding with dirty cache", c.lastAdmitted, c.cacheInvalidated)
+			c.synced = true
+			return true
+		}
 		c.cond.Wait()
 	}
+	return false
 }
 
 // Admit invalidates the cache and blocks Lock until the admitted pod has synced
@@ -1144,6 +1160,7 @@ func (c *podSyncLocker) Lock() {
 func (c *podSyncLocker) Admit(pod string) {
 	c.synced = false
 	c.lastAdmitted = pod
+	c.cacheInvalidated = time.Now()
 }
 
 // Unlock releases the lock.

--- a/main.go
+++ b/main.go
@@ -1115,42 +1115,46 @@ func (t *TPUWebhookServer) addPod(obj interface{}) {
 // podSyncLocker provides a lock that allows the mutating webhook to guarantee
 // only one pod is mutated at a time and the cache is valid during requests.
 type podSyncLocker struct {
-	m      sync.Mutex
-	cond   *sync.Cond
-	synced bool
-
-	// lastAdmitted and cacheInvalidated are only valid when synced is false.
-	// lastAdmitted is the pod ID that needs to hit the informer, and
-	// cacheInvalidated is the time at which we started waiting for it.
-	lastAdmitted     string
-	cacheInvalidated time.Time
+	m            sync.Mutex
+	wakeChan     chan struct{}
+	synced       bool
+	lastAdmitted string
 }
 
 func newPodSyncLocker() *podSyncLocker {
 	c := &podSyncLocker{
-		synced: true,
+		wakeChan: make(chan struct{}),
+		synced:   true,
 	}
-	c.cond = sync.NewCond(&c.m)
 	return c
 }
 
 // Lock blocks until both all callers release the lock and the cache is
 // up-to-date.
 func (c *podSyncLocker) Lock(timeout time.Duration) (timedout bool) {
-	// Acquire the lock (which must be held to block on the condition) as well
-	// as to guarantee only one mutate request is in-flight.
-	// If the cache is not synced, block on the condition for it to become
-	// synced.
+	// The lock must be held
+	// 1. While reading or writing c.synced, and
+	// 2. When the function exits.
+	// The lock does not need to be held while waiting for the cache sync or the
+	// timout.
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	c.m.Lock()
-	for !c.synced {
-		// If it has been too long between when the cache was marked invalid and
-		// now, then bail and proceed with a stale cache.
-		if time.Now().Sub(c.cacheInvalidated) > timeout {
-			klog.V(0).Infof("Waiting for pod %q admitted at %s timed out; proceeding with dirty cache", c.lastAdmitted, c.cacheInvalidated)
+	for !c.synced { // Lock is held while reading state.
+		c.m.Unlock() // Release lock while waiting to be unblocked.
+		select {
+		case <-c.wakeChan:
+			c.m.Lock()
+			continue // Try checking t.synced again with lock held.
+		case <-timer.C:
+			// If cache does not sync within the timeout, assume the
+			// lastAdmitted pod will never appear. Release the cache sync bit
+			// and return.
+			c.m.Lock()
+			klog.V(0).Infof("Timed out waiting for pod %q to be added to cache", c.lastAdmitted)
 			c.synced = true
 			return true
 		}
-		c.cond.Wait()
 	}
 	return false
 }
@@ -1160,7 +1164,6 @@ func (c *podSyncLocker) Lock(timeout time.Duration) (timedout bool) {
 func (c *podSyncLocker) Admit(pod string) {
 	c.synced = false
 	c.lastAdmitted = pod
-	c.cacheInvalidated = time.Now()
 }
 
 // Unlock releases the lock.
@@ -1179,7 +1182,13 @@ func (c *podSyncLocker) Receive(pod string) {
 	if pod == c.lastAdmitted {
 		c.synced = true
 		c.lastAdmitted = ""
-		c.cond.Signal()
+
+		// Wake by sending to wakeChan. Select with an empty default allows us
+		// to skip if there is no blocked request.
+		select {
+		case c.wakeChan <- struct{}{}:
+		default:
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1063,6 +1063,7 @@ func (t *TPUWebhookServer) addPod(obj interface{}) {
 
 	if pod.Spec.Containers == nil || !containerRequestingTPUs(pod.Spec.Containers...) {
 		// Pod does not use TPUs.
+		return
 	}
 	replicaIndex := pod.Labels[legacyReplicaIndexLabelKey]
 	if replicaIndex == "" {
@@ -1104,7 +1105,7 @@ type podSyncCond struct {
 
 func newPodSyncCond() *podSyncCond {
 	c := &podSyncCond{
-		wakeChan: make(chan struct{}),
+		wakeChan: make(chan struct{}, 1),
 		synced:   true,
 	}
 	return c
@@ -1135,6 +1136,17 @@ func (c *podSyncCond) Wait(timeout time.Duration) (timedout bool) {
 			klog.V(0).Infof("Timed out waiting for pod %q to be added to cache", c.lastAdmitted)
 			c.synced = true
 			return true
+		}
+	}
+
+	// Drain wakeChan of any pre-buffered events that were waiting before Wait
+	// was called.
+drain:
+	for {
+		select {
+		case <-c.wakeChan:
+		default:
+			break drain
 		}
 	}
 	return false

--- a/main.go
+++ b/main.go
@@ -796,7 +796,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 	} else {
 		// Fallback for older KubeRay versions that do not set K8s index labels.
 		// Wait for PodInformer cache to update from previous requests.
-		timedout := t.cacheCond.Wait(2 * time.Second)
+		timedout := t.cacheCond.Wait(1 * time.Second)
 		if timedout {
 			klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
 		}

--- a/main.go
+++ b/main.go
@@ -61,9 +61,9 @@ type slice struct {
 // TPUWebhookServer is a KubeRay TPU webhook server instance.
 type TPUWebhookServer struct {
 	// podLister is used to query Pods from an informer cache.
-	podLister   listersv1.PodLister
-	cacheMutex  sync.Mutex
-	podMutateMu *podSyncLocker
+	podLister  listersv1.PodLister
+	cacheMutex sync.Mutex
+	cacheCond  *podSyncCond
 }
 
 // patch is a JSON patch describing mutate operation(s) for an incoming object.
@@ -96,8 +96,8 @@ var (
 
 func NewTPUWebhookServer(podLister listersv1.PodLister) *TPUWebhookServer {
 	return &TPUWebhookServer{
-		podLister:   podLister,
-		podMutateMu: newPodSyncLocker(),
+		podLister: podLister,
+		cacheCond: newPodSyncCond(),
 	}
 }
 
@@ -696,21 +696,6 @@ func extractPod(admissionReview *admissionv1.AdmissionReview) (*corev1.Pod, erro
 	return &pod, nil
 }
 
-// waitTimeout helper function to sync.WaitGroup Wait() or timeout
-func waitTimeout(wait *sync.WaitGroup, timeout time.Duration) bool {
-	waitChan := make(chan struct{})
-	go func() {
-		defer close(waitChan)
-		wait.Wait()
-	}()
-	select {
-	case <-waitChan:
-		return true // Wait() returned
-	case <-time.After(timeout):
-		return false // Request timed out
-	}
-}
-
 // addEnvVarPatch is a helper to create a JSON patch to add an environment variable to a container.
 // It returns the updated patch slice and a boolean indicating that the env array now exists.
 func addEnvVarPatch(patches []patch, envVar corev1.EnvVar, path string, envArrayExists bool) ([]patch, bool) {
@@ -810,10 +795,8 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		}
 	} else {
 		// Fallback for older KubeRay versions that do not set K8s index labels.
-		// CRITICAL SECTION: Calculating the replica index, pod slice, and
-		// worker ID must happen one at a time with an up-to-date cache.
 		// Wait for PodInformer cache to update from previous requests.
-		timedout := t.podMutateMu.Lock(2 * time.Second)
+		timedout := t.cacheCond.Wait(2 * time.Second)
 		if timedout {
 			klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
 		}
@@ -821,7 +804,6 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		// query k8s client to populate sliceToTPUHosts
 		sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
 		if err != nil {
-			t.podMutateMu.Unlock()
 			return nil, err
 		}
 
@@ -829,13 +811,11 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
 		tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
 		if err != nil {
-			t.podMutateMu.Unlock()
 			return nil, err
 		}
 
-		// Update state for next request
-		t.podMutateMu.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
-		t.podMutateMu.Unlock()
+		// Update state for next request.
+		t.cacheCond.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
 
 		// Manually inject the replicaIndex label
 		injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
@@ -1108,38 +1088,39 @@ func (t *TPUWebhookServer) addPod(obj interface{}) {
 		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
 
 		// Inform the cache control mechanism of the pod id.
-		t.podMutateMu.Receive(uniquePodID)
+		t.cacheCond.Signal(uniquePodID)
 	}
 }
 
-// podSyncLocker provides a lock that allows the mutating webhook to guarantee
-// only one pod is mutated at a time and the cache is valid during requests.
-type podSyncLocker struct {
+// podSyncCond provides a synchronization primitive that allows the mutating
+// webhook to unblock one in-flight request at a time when the informer cache is
+// ready.
+type podSyncCond struct {
 	m            sync.Mutex
 	wakeChan     chan struct{}
 	synced       bool
 	lastAdmitted string
 }
 
-func newPodSyncLocker() *podSyncLocker {
-	c := &podSyncLocker{
+func newPodSyncCond() *podSyncCond {
+	c := &podSyncCond{
 		wakeChan: make(chan struct{}),
 		synced:   true,
 	}
 	return c
 }
 
-// Lock blocks until both all callers release the lock and the cache is
+// Wait blocks until the cache is up-to-date or the timeout is reached.
 // up-to-date.
-func (c *podSyncLocker) Lock(timeout time.Duration) (timedout bool) {
-	// The lock must be held
-	// 1. While reading or writing c.synced, and
-	// 2. When the function exits.
-	// The lock does not need to be held while waiting for the cache sync or the
-	// timout.
+func (c *podSyncCond) Wait(timeout time.Duration) (timedout bool) {
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+
+	// The lock must be held while reading or writing c.synced, but cannot be
+	// held while blocking on the channel or timer.
 	c.m.Lock()
+	defer c.m.Unlock()
+
 	for !c.synced { // Lock is held while reading state.
 		c.m.Unlock() // Release lock while waiting to be unblocked.
 		select {
@@ -1160,20 +1141,17 @@ func (c *podSyncLocker) Lock(timeout time.Duration) (timedout bool) {
 }
 
 // Admit invalidates the cache and blocks Lock until the admitted pod has synced
-// to the cache. The lock must be held.
-func (c *podSyncLocker) Admit(pod string) {
+// to the cache.
+func (c *podSyncCond) Admit(pod string) {
+	c.m.Lock()
+	defer c.m.Unlock()
 	c.synced = false
 	c.lastAdmitted = pod
 }
 
-// Unlock releases the lock.
-func (c *podSyncLocker) Unlock() {
-	c.m.Unlock()
-}
-
-// Receive marks a pod as received in the cache. The lock does not need to be
+// Signal marks a pod as received in the cache. The lock does not need to be
 // held.
-func (c *podSyncLocker) Receive(pod string) {
+func (c *podSyncCond) Signal(pod string) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	// If the pod received by the informer matches the one we last admitted --

--- a/main.go
+++ b/main.go
@@ -791,38 +791,8 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 			return nil, fmt.Errorf("failed to parse host index label: %w", err)
 		}
 	} else {
-		err := func() error {
-			t.cacheMutex.Lock()
-			defer t.cacheMutex.Unlock()
-
-			// Fallback for older KubeRay versions that do not set K8s index labels.
-			// Wait for PodInformer cache to update from previous requests.
-			timedout := t.cacheCond.Wait(1 * time.Second)
-			if timedout {
-				klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
-			}
-
-			// query k8s client to populate sliceToTPUHosts
-			sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
-			if err != nil {
-				return err
-			}
-
-			replicaIndex = getReplicaIndex(sliceToTPUHosts, clusterName, groupName, namespace)
-			podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
-			tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
-			if err != nil {
-				return err
-			}
-
-			// Update state for next request.
-			t.cacheCond.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
-
-			// Manually inject the replicaIndex label
-			injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
-
-			return nil
-		}()
+		// Fallback for older KubeRay versions that do not set K8s index labels.
+		replicaIndex, tpuWorkerID, err = t.legacyAssignIndices(pod, clusterName, groupName, namespace, numOfHosts, &patches)
 		if err != nil {
 			return nil, err
 		}
@@ -989,6 +959,39 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		return &pt
 	}()
 	return admissionResponse, nil
+}
+
+// legacyAssignIndices assigns replicaIndex and tpuWorkerID for older KubeRay versions.
+func (t *TPUWebhookServer) legacyAssignIndices(pod *corev1.Pod, clusterName, groupName, namespace string, numOfHosts int32, patches *[]patch) (int, int, error) {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+
+	// Wait for PodInformer cache to update from previous requests.
+	timedout := t.cacheCond.Wait(1 * time.Second)
+	if timedout {
+		klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
+	}
+
+	// Query k8s client to populate sliceToTPUHosts.
+	sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	replicaIndex := getReplicaIndex(sliceToTPUHosts, clusterName, groupName, namespace)
+	podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
+	tpuWorkerID, err := getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Update state for next request.
+	t.cacheCond.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
+
+	// Manually inject the replicaIndex label
+	injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, patches)
+
+	return replicaIndex, tpuWorkerID, nil
 }
 
 // buildTLSConfig builds a TLS config for the webhook server.

--- a/main.go
+++ b/main.go
@@ -103,9 +103,6 @@ func NewTPUWebhookServer(podLister listersv1.PodLister) *TPUWebhookServer {
 
 // Mutate handles http Request for Pod creation and writes a response
 func (t *TPUWebhookServer) Mutate(w http.ResponseWriter, r *http.Request) {
-	t.cacheMutex.Lock()
-	defer t.cacheMutex.Unlock()
-
 	admissionReview := &admissionv1.AdmissionReview{}
 	if err := json.NewDecoder(r.Body).Decode(admissionReview); err != nil {
 		http.Error(w, "Error decoding request body", http.StatusBadRequest)
@@ -794,31 +791,41 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 			return nil, fmt.Errorf("failed to parse host index label: %w", err)
 		}
 	} else {
-		// Fallback for older KubeRay versions that do not set K8s index labels.
-		// Wait for PodInformer cache to update from previous requests.
-		timedout := t.cacheCond.Wait(1 * time.Second)
-		if timedout {
-			klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
-		}
+		err := func() error {
+			t.cacheMutex.Lock()
+			defer t.cacheMutex.Unlock()
 
-		// query k8s client to populate sliceToTPUHosts
-		sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
+			// Fallback for older KubeRay versions that do not set K8s index labels.
+			// Wait for PodInformer cache to update from previous requests.
+			timedout := t.cacheCond.Wait(1 * time.Second)
+			if timedout {
+				klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
+			}
+
+			// query k8s client to populate sliceToTPUHosts
+			sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
+			if err != nil {
+				return err
+			}
+
+			replicaIndex = getReplicaIndex(sliceToTPUHosts, clusterName, groupName, namespace)
+			podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
+			tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
+			if err != nil {
+				return err
+			}
+
+			// Update state for next request.
+			t.cacheCond.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
+
+			// Manually inject the replicaIndex label
+			injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
+
+			return nil
+		}()
 		if err != nil {
 			return nil, err
 		}
-
-		replicaIndex = getReplicaIndex(sliceToTPUHosts, clusterName, groupName, namespace)
-		podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
-		tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
-		if err != nil {
-			return nil, err
-		}
-
-		// Update state for next request.
-		t.cacheCond.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
-
-		// Manually inject the replicaIndex label
-		injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
 	}
 
 	headlessServiceName := generateHeadlessServiceName(clusterName)

--- a/main.go
+++ b/main.go
@@ -61,11 +61,9 @@ type slice struct {
 // TPUWebhookServer is a KubeRay TPU webhook server instance.
 type TPUWebhookServer struct {
 	// podLister is used to query Pods from an informer cache.
-	podLister    listersv1.PodLister
-	cacheMutex   sync.Mutex
-	wg           sync.WaitGroup
-	waiting      int
-	lastAdmitted string
+	podLister   listersv1.PodLister
+	cacheMutex  sync.Mutex
+	podMutateMu *podSyncLocker
 }
 
 // patch is a JSON patch describing mutate operation(s) for an incoming object.
@@ -98,7 +96,8 @@ var (
 
 func NewTPUWebhookServer(podLister listersv1.PodLister) *TPUWebhookServer {
 	return &TPUWebhookServer{
-		podLister: podLister,
+		podLister:   podLister,
+		podMutateMu: newPodSyncLocker(),
 	}
 }
 
@@ -811,19 +810,15 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		}
 	} else {
 		// Fallback for older KubeRay versions that do not set K8s index labels.
-		// Wait for PodInformer cache to update from previous requests or timeout.
-		if waitTimeout(&t.wg, time.Second*1) {
-			klog.V(1).Info("MutatePod", "PodInformer AddFunc called for prior admission request")
-		} else {
-			klog.V(1).Info("MutatePod", "Timed out waiting for PodInformer AddFunc")
-		}
-		// Add 1 to the WaitGroup to represent the pending Pod to the cache
-		defer t.wg.Add(1)
-		t.waiting += 1
+		// CRITICAL SECTION: Calculating the replica index, pod slice, and
+		// worker ID must happen one at a time with an up-to-date cache.
+		// Wait for PodInformer cache to update from previous requests.
+		t.podMutateMu.Lock()
 
 		// query k8s client to populate sliceToTPUHosts
 		sliceToTPUHosts, err := t.getSliceToTPUHosts(clusterName, groupName, namespace, numOfHosts)
 		if err != nil {
+			t.podMutateMu.Unlock()
 			return nil, err
 		}
 
@@ -831,11 +826,13 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 		podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
 		tpuWorkerID, err = getNextWorkerID(sliceToTPUHosts, podSlice, namespace, replicaIndex)
 		if err != nil {
+			t.podMutateMu.Unlock()
 			return nil, err
 		}
 
 		// Update state for next request
-		t.lastAdmitted = fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID)
+		t.podMutateMu.Admit(fmt.Sprintf("%s-%s-%s-%d-%d", namespace, clusterName, groupName, replicaIndex, tpuWorkerID))
+		t.podMutateMu.Unlock()
 
 		// Manually inject the replicaIndex label
 		injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
@@ -1076,68 +1073,96 @@ func init() {
 	klog.InitFlags(nil)
 }
 
-// isLastAdmittedPod returns True if Pod matches the last Pod admitted by the webhook server
-func (t *TPUWebhookServer) isLastAdmittedPod(pod *corev1.Pod) (bool, error) {
-	if pod.Spec.Containers == nil || !containerRequestingTPUs(pod.Spec.Containers...) {
-		// Pod does not use TPUs
-		return false, nil
-	}
-	replicaIndex := pod.Labels[legacyReplicaIndexLabelKey]
-	if replicaIndex == "" {
-		// Pod was not mutated by the webhook
-		return false, nil
-	}
-	clusterName := pod.Labels[utils.RayClusterLabelKey]
-	if clusterName == "" {
-		return false, errors.New("Ray Pod created by KubeRay missing RayCluster label")
-	}
-	namespace := pod.Namespace
-	for _, container := range pod.Spec.Containers {
-		if !containerRequestingTPUs(container) {
-			// Skip to the next container
-			continue
-		}
-		tpuWorkerID, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
-		if tpuWorkerID == "" {
-			// TPU pod was not intercepted by the webhook
-			return false, nil
-		}
-		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
-		if uniquePodID == t.lastAdmitted {
-			// Pod matches the last TPU worker Pod intercepted by the webhook server
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // addPod allows next goroutine to start once the webhook PodInformer cache updates
 func (t *TPUWebhookServer) addPod(obj interface{}) {
 	pod := obj.(*corev1.Pod)
 	klog.V(1).InfoS("addPod", "Pod", pod.Namespace+"/"+pod.Name, "Time", time.Now())
 
-	if t.lastAdmitted == "" {
-		// There is not a pending TPU worker Pod to the informer cache, unblock if waiting and return
-		for t.waiting > 0 {
-			t.wg.Done()
-			t.waiting -= 1
+	if pod.Spec.Containers == nil || !containerRequestingTPUs(pod.Spec.Containers...) {
+		// Pod does not use TPUs.
+	}
+	replicaIndex := pod.Labels[legacyReplicaIndexLabelKey]
+	if replicaIndex == "" {
+		// Pod was not mutated by the webhook.
+		return
+	}
+	clusterName := pod.Labels[utils.RayClusterLabelKey]
+	if clusterName == "" {
+		klog.V(1).InfoS("Ray Pod created by KubeRay missing RayCluster label")
+		return
+	}
+	namespace := pod.Namespace
+	for _, container := range pod.Spec.Containers {
+		if !containerRequestingTPUs(container) {
+			// Skip to the next container.
+			continue
 		}
-		return
+		tpuWorkerID, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
+		if tpuWorkerID == "" {
+			// TPU pod was not intercepted by the webhook
+			continue
+		}
+		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
+
+		// Inform the cache control mechanism of the pod id.
+		t.podMutateMu.Receive(uniquePodID)
 	}
-	if t.waiting == 0 {
-		// Webhook is not waiting, no-op
-		return
+}
+
+// podSyncLocker provides a lock that allows the mutating webhook to guarantee
+// only one pod is mutated at a time and the cache is valid during requests.
+type podSyncLocker struct {
+	m            sync.Mutex
+	cond         *sync.Cond
+	synced       bool
+	lastAdmitted string
+}
+
+func newPodSyncLocker() *podSyncLocker {
+	c := &podSyncLocker{
+		synced: true,
 	}
-	// Check if Pod in cache is the last admitted TPU Pod
-	isLastAdmitted, err := t.isLastAdmittedPod(pod)
-	if err != nil {
-		klog.Errorf("Invalid addPod: %s", err)
-		return
+	c.cond = sync.NewCond(&c.m)
+	return c
+}
+
+// Lock blocks until both all callers release the lock and the cache is
+// up-to-date.
+func (c *podSyncLocker) Lock() {
+	// Acquire the lock (which must be held to block on the condition) as well
+	// as to guarantee only one mutate request is in-flight.
+	// If the cache is not synced, block on the condition for it to become
+	// synced.
+	c.m.Lock()
+	for !c.synced {
+		c.cond.Wait()
 	}
-	if isLastAdmitted {
-		// Informer cache has been updated, unblock the next Mutate call
-		t.wg.Done()
-		t.waiting -= 1
+}
+
+// Admit invalidates the cache and blocks Lock until the admitted pod has synced
+// to the cache. The lock must be held.
+func (c *podSyncLocker) Admit(pod string) {
+	c.synced = false
+	c.lastAdmitted = pod
+}
+
+// Unlock releases the lock.
+func (c *podSyncLocker) Unlock() {
+	c.m.Unlock()
+}
+
+// Receive marks a pod as received in the cache. The lock does not need to be
+// held.
+func (c *podSyncLocker) Receive(pod string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	// If the pod received by the informer matches the one we last admitted --
+	// and were waiting for -- then we can mark the cache as synced and wake one
+	// in-flight request.
+	if pod == c.lastAdmitted {
+		c.synced = true
+		c.lastAdmitted = ""
+		c.cond.Signal()
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1060,20 +1060,24 @@ func init() {
 func (t *TPUWebhookServer) addPod(obj interface{}) {
 	pod := obj.(*corev1.Pod)
 	klog.V(1).InfoS("addPod", "Pod", pod.Namespace+"/"+pod.Name, "Time", time.Now())
+	if _, err := t.isLastAdmittedPod(pod); err != nil {
+		klog.V(0).ErrorS(err, "Failed to verify local cache from pod informer update", "name", pod.GetName())
+	}
+}
 
+func (t *TPUWebhookServer) isLastAdmittedPod(pod *corev1.Pod) (bool, error) {
 	if pod.Spec.Containers == nil || !containerRequestingTPUs(pod.Spec.Containers...) {
 		// Pod does not use TPUs.
-		return
+		return false, nil
 	}
 	replicaIndex := pod.Labels[legacyReplicaIndexLabelKey]
 	if replicaIndex == "" {
 		// Pod was not mutated by the webhook.
-		return
+		return false, nil
 	}
 	clusterName := pod.Labels[utils.RayClusterLabelKey]
 	if clusterName == "" {
-		klog.V(1).InfoS("Ray Pod created by KubeRay missing RayCluster label")
-		return
+		return false, errors.New("Ray Pod created by KubeRay missing RayCluster label")
 	}
 	namespace := pod.Namespace
 	for _, container := range pod.Spec.Containers {
@@ -1083,14 +1087,16 @@ func (t *TPUWebhookServer) addPod(obj interface{}) {
 		}
 		tpuWorkerID, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
 		if tpuWorkerID == "" {
-			// TPU pod was not intercepted by the webhook
+			// TPU pod container was not intercepted by the webhook.
 			continue
 		}
-		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
 
-		// Inform the cache control mechanism of the pod id.
-		t.cacheCond.Signal(uniquePodID)
+		// The pod has a TPU-configured container. There can only be one per
+		// pod. Inform the cache control mechanism of the pod id.
+		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
+		return t.cacheCond.Signal(uniquePodID), nil
 	}
+	return false, nil
 }
 
 // podSyncCond provides a synchronization primitive that allows the mutating
@@ -1162,8 +1168,8 @@ func (c *podSyncCond) Admit(pod string) {
 }
 
 // Signal marks a pod as received in the cache. The lock does not need to be
-// held.
-func (c *podSyncCond) Signal(pod string) {
+// held. Returns true if the cache is marked synced as a result.
+func (c *podSyncCond) Signal(pod string) bool {
 	c.m.Lock()
 	defer c.m.Unlock()
 	// If the pod received by the informer matches the one we last admitted --
@@ -1179,7 +1185,10 @@ func (c *podSyncCond) Signal(pod string) {
 		case c.wakeChan <- struct{}{}:
 		default:
 		}
+
+		return true
 	}
+	return false
 }
 
 // startServer sets up and runs the webhook's HTTP server.

--- a/main.go
+++ b/main.go
@@ -967,8 +967,8 @@ func (t *TPUWebhookServer) legacyAssignIndices(pod *corev1.Pod, clusterName, gro
 	defer t.cacheMutex.Unlock()
 
 	// Wait for PodInformer cache to update from previous requests.
-	timedout := t.cacheCond.Wait(1 * time.Second)
-	if timedout {
+	timedOut := t.cacheCond.Wait(1 * time.Second)
+	if timedOut {
 		klog.V(0).Infof("Mutating pod %s with a stale cache", pod.GetName())
 	}
 
@@ -1101,8 +1101,10 @@ func (t *TPUWebhookServer) isLastAdmittedPod(pod *corev1.Pod) (bool, error) {
 			continue
 		}
 
-		// The pod has a TPU-configured container. There can only be one per
-		// pod. Inform the cache control mechanism of the pod id.
+		// The pod has a TPU-configured container. Inform the cache control
+		// mechanism of the pod id. It's sufficient return after inspecting the
+		// first TPU container (there can be no second TPU container with a
+		// different id).
 		uniquePodID := fmt.Sprintf("%s-%s-%s-%s", namespace, clusterName, replicaIndex, tpuWorkerID)
 		return t.cacheCond.Signal(uniquePodID), nil
 	}

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1468,12 +1468,12 @@ func Test_IsLastAdmittedPod(t *testing.T) {
 				tpuWebhookServer.cacheCond.lastAdmitted = tc.lastAdmitted
 			}
 
-			//isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)
-			//if err != nil {
-			//	assert.Equal(t, tc.expectedError, err)
-			//} else {
-			//	assert.Equal(t, tc.isLastAdmitted, isLastAdmitted)
-			//}
+			isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)
+			if err != nil {
+				assert.Equal(t, tc.expectedError, err)
+			} else {
+				assert.Equal(t, tc.isLastAdmitted, isLastAdmitted)
+			}
 		})
 	}
 }

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1465,7 +1465,9 @@ func Test_IsLastAdmittedPod(t *testing.T) {
 						}
 					}
 				}
-				tpuWebhookServer.cacheCond.lastAdmitted = tc.lastAdmitted
+				if len(tc.lastAdmitted) > 0 {
+					tpuWebhookServer.cacheCond.lastAdmitted = tc.lastAdmitted
+				}
 			}
 
 			isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1465,7 +1465,7 @@ func Test_IsLastAdmittedPod(t *testing.T) {
 						}
 					}
 				}
-				tpuWebhookServer.podMutateMu.lastAdmitted = tc.lastAdmitted
+				tpuWebhookServer.cacheCond.lastAdmitted = tc.lastAdmitted
 			}
 
 			//isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/synctest"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -2103,136 +2104,139 @@ func Test_MutatePod_V7x(t *testing.T) {
 }
 
 func TestMutatePodLoad(t *testing.T) {
-	// Parameters for the load test
-	numCreations := 50
-	numDeletions := 20
-	clusterName := "load-test-cluster"
-	groupName := "tpu-group"
-	namespace := "default"
+	synctest.Test(t, func(t *testing.T) {
+		// Parameters for the load test
+		numCreations := 50
+		numDeletions := 20
+		clusterName := "load-test-cluster"
+		groupName := "tpu-group"
+		namespace := "default"
 
-	// Setup fake clientset and informer
-	fakeClient := fake.NewSimpleClientset()
-	factory := informers.NewSharedInformerFactory(fakeClient, 0)
-	podInformer := factory.Core().V1().Pods().Informer()
-	podLister := factory.Core().V1().Pods().Lister()
+		// Setup fake clientset and informer
+		fakeClient := fake.NewSimpleClientset()
+		// Use a non-zero resync period to avoid hitting non-bubbled global channels in client-go
+		factory := informers.NewSharedInformerFactory(fakeClient, 12*time.Hour)
+		podInformer := factory.Core().V1().Pods().Informer()
+		podLister := factory.Core().V1().Pods().Lister()
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	factory.Start(stopCh)
-	cache.WaitForCacheSync(stopCh, podInformer.HasSynced)
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		factory.Start(stopCh)
+		synctest.Wait()
 
-	tpuWebhookServer := NewTPUWebhookServer(podLister)
-	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: tpuWebhookServer.addPod,
-	})
+		tpuWebhookServer := NewTPUWebhookServer(podLister)
+		podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: tpuWebhookServer.addPod,
+		})
 
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-	createdPods := make(map[string]*corev1.Pod)
+		var wg sync.WaitGroup
+		var mu sync.Mutex
+		createdPods := make(map[string]*corev1.Pod)
 
-	// Channel to track pods ready for deletion
-	toDelete := make(chan string, numCreations)
+		// Channel to track pods ready for deletion
+		toDelete := make(chan string, numCreations)
 
-	// 1. Goroutine for concurrent creations
-	wg.Add(numCreations)
-	for i := 0; i < numCreations; i++ {
-		go func(id int) {
-			defer wg.Done()
+		// 1. Goroutine for concurrent creations
+		wg.Add(numCreations)
+		for i := 0; i < numCreations; i++ {
+			go func(id int) {
+				defer wg.Done()
 
-			pod := getTestTPUWorker(clusterName, groupName, namespace, "tpu-v4-podslice", "2x2x2", "4")
-			pod.Name = fmt.Sprintf("pod-%d", id)
+				pod := getTestTPUWorker(clusterName, groupName, namespace, "tpu-v4-podslice", "2x2x2", "4")
+				pod.Name = fmt.Sprintf("pod-%d", id)
 
-			admissionReview := getTestAdmissionReview("Pod", "CREATE")
-			jsonPod, _ := json.Marshal(pod)
-			admissionReview.Request.Object.Raw = jsonPod
-			admissionReview.Request.Object = runtime.RawExtension{Object: pod}
-			admissionReview.Request.Namespace = namespace
+				admissionReview := getTestAdmissionReview("Pod", "CREATE")
+				jsonPod, _ := json.Marshal(pod)
+				admissionReview.Request.Object.Raw = jsonPod
+				admissionReview.Request.Object = runtime.RawExtension{Object: pod}
+				admissionReview.Request.Namespace = namespace
 
-			body, _ := json.Marshal(admissionReview)
-			req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
-			w := httptest.NewRecorder()
+				body, _ := json.Marshal(admissionReview)
+				req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
+				w := httptest.NewRecorder()
 
-			tpuWebhookServer.Mutate(w, req)
+				tpuWebhookServer.Mutate(w, req)
 
-			if w.Code != http.StatusOK {
-				t.Errorf("Mutation failed for pod %d: %s", id, w.Body.String())
-				return
-			}
+				if w.Code != http.StatusOK {
+					t.Errorf("Mutation failed for pod %d: %s", id, w.Body.String())
+					return
+				}
 
-			var resp admissionv1.AdmissionReview
-			json.Unmarshal(w.Body.Bytes(), &resp)
+				var resp admissionv1.AdmissionReview
+				json.Unmarshal(w.Body.Bytes(), &resp)
 
-			// Apply patches to the pod
-			patchedPod := applyPatches(t, pod, resp.Response.Patch)
+				// Apply patches to the pod
+				patchedPod := applyPatches(t, pod, resp.Response.Patch)
 
-			// Persist to fake client (triggers informer AddFunc)
-			_, err := fakeClient.CoreV1().Pods(namespace).Create(context.TODO(), patchedPod, metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("Failed to create pod in fake client: %v", err)
-				return
-			}
-
-			mu.Lock()
-			createdPods[patchedPod.Name] = patchedPod
-			mu.Unlock()
-
-			toDelete <- patchedPod.Name
-		}(i)
-	}
-
-	// 2. Goroutine for concurrent deletions
-	var delWg sync.WaitGroup
-	delWg.Add(numDeletions)
-	go func() {
-		for i := 0; i < numDeletions; i++ {
-			podName := <-toDelete
-			go func(name string) {
-				defer delWg.Done()
-				// Simulate some delay
-				time.Sleep(10 * time.Millisecond)
-				err := fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+				// Persist to fake client (triggers informer AddFunc)
+				_, err := fakeClient.CoreV1().Pods(namespace).Create(context.TODO(), patchedPod, metav1.CreateOptions{})
 				if err != nil {
-					t.Errorf("Failed to delete pod %s: %v", name, err)
+					t.Errorf("Failed to create pod in fake client: %v", err)
+					return
 				}
+
 				mu.Lock()
-				delete(createdPods, name)
+				createdPods[patchedPod.Name] = patchedPod
 				mu.Unlock()
-			}(podName)
+
+				toDelete <- patchedPod.Name
+			}(i)
 		}
-	}()
 
-	wg.Wait()
-	delWg.Wait()
+		// 2. Goroutine for concurrent deletions
+		var delWg sync.WaitGroup
+		delWg.Add(numDeletions)
+		go func() {
+			for i := 0; i < numDeletions; i++ {
+				podName := <-toDelete
+				go func(name string) {
+					defer delWg.Done()
+					// Simulate some delay
+					time.Sleep(10 * time.Millisecond)
+					err := fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+					if err != nil {
+						t.Errorf("Failed to delete pod %s: %v", name, err)
+					}
+					mu.Lock()
+					delete(createdPods, name)
+					mu.Unlock()
+				}(podName)
+			}
+		}()
 
-	// Wait for informer to catch up
-	time.Sleep(500 * time.Millisecond)
+		wg.Wait()
+		delWg.Wait()
 
-	// Final verification
-	finalPods, _ := fakeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-	expectedCount := numCreations - numDeletions
-	assert.Equal(t, expectedCount, len(finalPods.Items), "Final pod count mismatch")
+		// Wait for informer to catch up
+		synctest.Wait()
 
-	workerIDs := make(map[string]bool)
-	for _, p := range finalPods.Items {
-		replicaIndex := p.Labels[legacyReplicaIndexLabelKey]
-		// Find TPU_WORKER_ID in env
-		var workerID string
-		for _, c := range p.Spec.Containers {
-			for _, env := range c.Env {
-				if env.Name == "TPU_WORKER_ID" {
-					workerID = env.Value
-					break
+		// Final verification
+		finalPods, _ := fakeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		expectedCount := numCreations - numDeletions
+		assert.Equal(t, expectedCount, len(finalPods.Items), "Final pod count mismatch")
+
+		workerIDs := make(map[string]bool)
+		for _, p := range finalPods.Items {
+			replicaIndex := p.Labels[legacyReplicaIndexLabelKey]
+			// Find TPU_WORKER_ID in env
+			var workerID string
+			for _, c := range p.Spec.Containers {
+				for _, env := range c.Env {
+					if env.Name == "TPU_WORKER_ID" {
+						workerID = env.Value
+						break
+					}
 				}
 			}
-		}
 
-		key := fmt.Sprintf("%s-%s", replicaIndex, workerID)
-		if workerIDs[key] {
-			t.Errorf("Duplicate (replicaIndex, TPU_WORKER_ID) found: %s", key)
+			key := fmt.Sprintf("%s-%s", replicaIndex, workerID)
+			if workerIDs[key] {
+				t.Errorf("Duplicate (replicaIndex, TPU_WORKER_ID) found: %s", key)
+			}
+			workerIDs[key] = true
+			klog.Infof("Pod %s: %s", p.Name, key)
 		}
-		workerIDs[key] = true
-		klog.Infof("Pod %s: %s", p.Name, key)
-	}
+	})
 }
 
 // applyPatches is a crude way to apply JSON patches for testing purposes

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -2105,6 +2105,47 @@ func Test_MutatePod_V7x(t *testing.T) {
 	}
 }
 
+// TestLegacyMutateGracefulDegradation verifies that two mutate requests can
+// concurrently complete without a cache sync, falling back to a timeout.
+func TestLegacyMutateGracefulDegradation(t *testing.T) {
+	// Running under synctest allows the timeout to occur instantly.
+	synctest.Test(t, func(t *testing.T) {
+		// Setup fake clientset and informer
+		fakeClient := fake.NewSimpleClientset()
+		// Use a non-zero resync period to avoid hitting non-bubbled global channels in client-go
+		factory := informers.NewSharedInformerFactory(fakeClient, 12*time.Hour)
+		podLister := factory.Core().V1().Pods().Lister()
+
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		factory.Start(stopCh)
+		synctest.Wait()
+
+		// Set up server with no informer callback.
+		tpuWebhookServer := NewTPUWebhookServer(podLister)
+
+		var wg sync.WaitGroup
+		for id := range 2 {
+			pod := getTestTPUWorker("my-cluster", "my-group", "default", "tpu-v4-podslice", "2x2x2", "4")
+			pod.Name = fmt.Sprintf("pod-%d", id)
+
+			admissionReview := getTestAdmissionReview("Pod", "CREATE")
+			jsonPod, _ := json.Marshal(pod)
+			admissionReview.Request.Object.Raw = jsonPod
+			admissionReview.Request.Object = runtime.RawExtension{Object: pod}
+			admissionReview.Request.Namespace = "default"
+
+			body, _ := json.Marshal(admissionReview)
+			req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+
+			wg.Go(func() { tpuWebhookServer.Mutate(w, req) })
+		}
+
+		wg.Wait()
+	})
+}
+
 func TestMutatePodLoad(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		// Parameters for the load test

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -10,8 +12,10 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"encoding/json"
@@ -34,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 )
 
@@ -1459,15 +1464,15 @@ func Test_IsLastAdmittedPod(t *testing.T) {
 						}
 					}
 				}
-				tpuWebhookServer.lastAdmitted = tc.lastAdmitted
+				tpuWebhookServer.podMutateMu.lastAdmitted = tc.lastAdmitted
 			}
 
-			isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)
-			if err != nil {
-				assert.Equal(t, tc.expectedError, err)
-			} else {
-				assert.Equal(t, tc.isLastAdmitted, isLastAdmitted)
-			}
+			//isLastAdmitted, err := tpuWebhookServer.isLastAdmittedPod(testPod)
+			//if err != nil {
+			//	assert.Equal(t, tc.expectedError, err)
+			//} else {
+			//	assert.Equal(t, tc.isLastAdmitted, isLastAdmitted)
+			//}
 		})
 	}
 }
@@ -2095,4 +2100,209 @@ func Test_MutatePod_V7x(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMutatePodLoad(t *testing.T) {
+	// Parameters for the load test
+	numCreations := 50
+	numDeletions := 20
+	clusterName := "load-test-cluster"
+	groupName := "tpu-group"
+	namespace := "default"
+
+	// Setup fake clientset and informer
+	fakeClient := fake.NewSimpleClientset()
+	factory := informers.NewSharedInformerFactory(fakeClient, 0)
+	podInformer := factory.Core().V1().Pods().Informer()
+	podLister := factory.Core().V1().Pods().Lister()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	factory.Start(stopCh)
+	cache.WaitForCacheSync(stopCh, podInformer.HasSynced)
+
+	tpuWebhookServer := NewTPUWebhookServer(podLister)
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: tpuWebhookServer.addPod,
+	})
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	createdPods := make(map[string]*corev1.Pod)
+
+	// Channel to track pods ready for deletion
+	toDelete := make(chan string, numCreations)
+
+	// 1. Goroutine for concurrent creations
+	wg.Add(numCreations)
+	for i := 0; i < numCreations; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			pod := getTestTPUWorker(clusterName, groupName, namespace, "tpu-v4-podslice", "2x2x2", "4")
+			pod.Name = fmt.Sprintf("pod-%d", id)
+
+			admissionReview := getTestAdmissionReview("Pod", "CREATE")
+			jsonPod, _ := json.Marshal(pod)
+			admissionReview.Request.Object.Raw = jsonPod
+			admissionReview.Request.Object = runtime.RawExtension{Object: pod}
+			admissionReview.Request.Namespace = namespace
+
+			body, _ := json.Marshal(admissionReview)
+			req := httptest.NewRequest("POST", "/mutate", bytes.NewReader(body))
+			w := httptest.NewRecorder()
+
+			tpuWebhookServer.Mutate(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Mutation failed for pod %d: %s", id, w.Body.String())
+				return
+			}
+
+			var resp admissionv1.AdmissionReview
+			json.Unmarshal(w.Body.Bytes(), &resp)
+
+			// Apply patches to the pod
+			patchedPod := applyPatches(t, pod, resp.Response.Patch)
+
+			// Persist to fake client (triggers informer AddFunc)
+			_, err := fakeClient.CoreV1().Pods(namespace).Create(context.TODO(), patchedPod, metav1.CreateOptions{})
+			if err != nil {
+				t.Errorf("Failed to create pod in fake client: %v", err)
+				return
+			}
+
+			mu.Lock()
+			createdPods[patchedPod.Name] = patchedPod
+			mu.Unlock()
+
+			toDelete <- patchedPod.Name
+		}(i)
+	}
+
+	// 2. Goroutine for concurrent deletions
+	var delWg sync.WaitGroup
+	delWg.Add(numDeletions)
+	go func() {
+		for i := 0; i < numDeletions; i++ {
+			podName := <-toDelete
+			go func(name string) {
+				defer delWg.Done()
+				// Simulate some delay
+				time.Sleep(10 * time.Millisecond)
+				err := fakeClient.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+				if err != nil {
+					t.Errorf("Failed to delete pod %s: %v", name, err)
+				}
+				mu.Lock()
+				delete(createdPods, name)
+				mu.Unlock()
+			}(podName)
+		}
+	}()
+
+	wg.Wait()
+	delWg.Wait()
+
+	// Wait for informer to catch up
+	time.Sleep(500 * time.Millisecond)
+
+	// Final verification
+	finalPods, _ := fakeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	expectedCount := numCreations - numDeletions
+	assert.Equal(t, expectedCount, len(finalPods.Items), "Final pod count mismatch")
+
+	workerIDs := make(map[string]bool)
+	for _, p := range finalPods.Items {
+		replicaIndex := p.Labels[legacyReplicaIndexLabelKey]
+		// Find TPU_WORKER_ID in env
+		var workerID string
+		for _, c := range p.Spec.Containers {
+			for _, env := range c.Env {
+				if env.Name == "TPU_WORKER_ID" {
+					workerID = env.Value
+					break
+				}
+			}
+		}
+
+		key := fmt.Sprintf("%s-%s", replicaIndex, workerID)
+		if workerIDs[key] {
+			t.Errorf("Duplicate (replicaIndex, TPU_WORKER_ID) found: %s", key)
+		}
+		workerIDs[key] = true
+		klog.Infof("Pod %s: %s", p.Name, key)
+	}
+}
+
+// applyPatches is a crude way to apply JSON patches for testing purposes
+func applyPatches(t *testing.T, pod *corev1.Pod, patchBytes []byte) *corev1.Pod {
+	if len(patchBytes) == 0 {
+		return pod
+	}
+	var patches []patch
+	err := json.Unmarshal(patchBytes, &patches)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal patches: %v", err)
+	}
+
+	patchedPod := pod.DeepCopy()
+	for _, p := range patches {
+		op := p["op"].(string)
+		path := p["path"].(string)
+		value := p["value"]
+
+		if op == "add" || op == "replace" {
+			if path == "/metadata/labels/replicaIndex" {
+				if patchedPod.Labels == nil {
+					patchedPod.Labels = make(map[string]string)
+				}
+				patchedPod.Labels[legacyReplicaIndexLabelKey] = value.(string)
+			} else if path == "/spec/hostname" {
+				patchedPod.Spec.Hostname = value.(string)
+			} else if path == "/spec/subdomain" {
+				patchedPod.Spec.Subdomain = value.(string)
+			} else if path == "/spec/containers/0/env" {
+				// This is a bit complex as it can be adding to an existing list or creating a new one
+				// In our case, we know it's adding or replacing.
+				// For simplicity in this test, we'll just handle the case where it's a list of env vars.
+				if envs, ok := value.([]any); ok {
+					for _, e := range envs {
+						eMap := e.(map[string]any)
+						name := eMap["name"].(string)
+						var value string
+						if v, ok := eMap["value"]; ok && v != nil {
+							value = v.(string)
+						}
+						patchedPod.Spec.Containers[0].Env = append(patchedPod.Spec.Containers[0].Env, corev1.EnvVar{
+							Name:  name,
+							Value: value,
+						})
+					}
+				} else if env, ok := value.(map[string]any); ok {
+					name := env["name"].(string)
+					var value string
+					if v, ok := env["value"]; ok && v != nil {
+						value = v.(string)
+					}
+					patchedPod.Spec.Containers[0].Env = append(patchedPod.Spec.Containers[0].Env, corev1.EnvVar{
+						Name:  name,
+						Value: value,
+					})
+				}
+			} else if path == "/spec/containers/0/env/-" {
+				eMap := value.(map[string]any)
+				name := eMap["name"].(string)
+				var valStr string
+				if v, ok := eMap["value"]; ok && v != nil {
+					valStr = v.(string)
+				}
+				patchedPod.Spec.Containers[0].Env = append(patchedPod.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  name,
+					Value: valStr,
+				})
+			}
+		}
+	}
+	return patchedPod
 }


### PR DESCRIPTION
- The concurrent request load test added fails due to data races with `go test -race . -v -run TestMutatePodLoad`.
- Reads and writes to t.wg, t.waiting and t.lastAdmitted were not synchronized.
- I tried encapsulating the sync logic in podSyncLocker with a sync.Mutex (to limit inflight requests) and a sync.Cond (to block while the pod informer cache is invalid).
- The test now passes with no data races.

Caveats
- The lastAdmitted test is not updated - deferring to refactor after rebasing on #29 
- ~~This lacks a timeout mechanism. I think the locker can store the time of the lastadmitted pod and clear the condition if too much time has passed.~~ I added the timeout.