### PR TITLE
Inject Torch TPU environment variables

### DIFF
--- a/e2e/webhook/tpu_pod_mutation_test.go
+++ b/e2e/webhook/tpu_pod_mutation_test.go
@@ -2,7 +2,6 @@
 
 package webhook
 
-
 import (
 	"context"
 	"flag"
@@ -125,6 +124,31 @@ func TestWebhookMutation_V6eMultiHost(t *testing.T) {
 
 	assert.Equal(t, 1, len(tpuNames), "All pods in the same slice should share the same TPU_NAME")
 	assert.Equal(t, 1, len(replicaIndices), "All pods in the same slice should share the same replicaIndex")
+}
+
+func TestWebhookMutation_TorchTpuEnvs(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v6e/v6e-8-single-host.yaml")
+
+	labelSelector := fmt.Sprintf("ray.io/cluster=%s", rayCluster.Name)
+	t.Logf("Looking for pods with selector: %s", labelSelector)
+
+	pods := waitForPods(t, labelSelector, 2)
+
+	for _, pod := range pods.Items {
+		if pod.Labels["ray.io/node-type"] == "worker" {
+			envVars := pod.Spec.Containers[0].Env
+			assert.True(t, hasEnvVar(envVars, "TORCH_TPU_TOPOLOGY"), "Missing TORCH_TPU_TOPOLOGY")
+			assert.True(t, hasEnvVar(envVars, "TORCH_TPU_SLICEBUILDER_ADDRESSES"), "Missing TORCH_TPU_SLICEBUILDER_ADDRESSES")
+
+			topology := envVarValue(envVars, "TORCH_TPU_TOPOLOGY")
+			assert.Equal(t, "2,4,1", topology, "Unexpected TORCH_TPU_TOPOLOGY")
+
+			addresses := envVarValue(envVars, "TORCH_TPU_SLICEBUILDER_ADDRESSES")
+			expectedAddresses := "localhost:8471,localhost:8472,localhost:8473,localhost:8474,localhost:8475,localhost:8476,localhost:8477,localhost:8478"
+			assert.Equal(t, expectedAddresses, addresses, "Unexpected TORCH_TPU_SLICEBUILDER_ADDRESSES")
+			break
+		}
+	}
 }
 
 func TestWebhookMutation_V6eMultiSlice(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -226,20 +226,45 @@ func getNumTPUHostsFromTopology(clusterName string, groupName string, namespace 
 	if topology == "" {
 		return 0, errors.New("TPU topology not specified")
 	}
-	topologyVals := strings.Split(topology, "x")
-	chips := 1
-	for i := 0; i < len(topologyVals); i++ {
-		dim, err := strconv.Atoi(topologyVals[i])
-		if err != nil {
-			klog.ErrorS(err, "getNumTPUHostsFromTopology", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "gke-tpu-topology", topology)
-			return 0, err
-		}
-		chips *= dim
+	topologyDims, err := getDimsFromTopology(topology)
+	if err != nil {
+		klog.ErrorS(err, "getNumTPUHostsFromTopology", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "gke-tpu-topology", topology)
+		return 0, err
 	}
+	chips := calculateTotalChips(topologyDims)
 	// calculate the # of VMs using # of chips per host
 	hosts := max(int32(chips)/int32(chipsPerHost), 1)
 	klog.V(1).InfoS("getNumTPUHostsFromTopology", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "topology", topology, "chips", chips, "hosts", hosts)
 	return hosts, nil
+}
+
+// getDimsFromTopology returns the dimensions of the TPU topology as a slice of int64.
+// It normalizes 2D topologies to 3D by adding a 3rd dimension of 1.
+func getDimsFromTopology(topology string) ([]int, error) {
+	var topologyDims []int
+	topologyDimStrs := strings.Split(topology, "x")
+	for _, s := range topologyDimStrs {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, err
+		}
+		topologyDims = append(topologyDims, n)
+	}
+
+	// Add 3rd dimension of 1 to 2D topologies (e.g. 2x2 -> 2x2x1).
+	if len(topologyDims) == 2 {
+		topologyDims = append(topologyDims, 1)
+	}
+	return topologyDims, nil
+}
+
+// calculateTotalChips returns the total number of chips in the topology.
+func calculateTotalChips(topologyDims []int) int {
+	totalChips := 1
+	for _, chips := range topologyDims {
+		totalChips *= int(chips)
+	}
+	return totalChips
 }
 
 // extractRayCluster returns RayCluster unmarshalled from an admission request
@@ -311,6 +336,77 @@ func injectHostnames(clusterName string, hostNames string, envPath string, conta
 	updatedPatches, envArrayExists = addEnvVarPatch(*patches, tpuWorkerHostNames, envPath, envArrayExists)
 	*patches = updatedPatches
 
+	return envArrayExists
+}
+
+// injectTorchTpuEnvsIfNeeded injects Torch TPU environment variables into a Pod if not already set.
+func injectTorchTpuEnvsIfNeeded(hostnames string, pod *corev1.Pod, container corev1.Container, envPath string, patches *[]patch, envArrayExists bool, tpuSupportTensorNode bool) (bool, error) {
+	if _, exists := getEnvironmentVariable("TORCH_TPU_TOPOLOGY", container); exists {
+		return envArrayExists, nil
+	}
+
+	topology := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-topology"]
+	topologyDims, err := getDimsFromTopology(topology)
+	if err != nil {
+		return envArrayExists, err
+	}
+
+	var topologyStrParts []string
+	for _, dim := range topologyDims {
+		topologyStrParts = append(topologyStrParts, strconv.Itoa(dim))
+	}
+
+	// Build TORCH_TPU_TOPOLOGY
+	topologyStr := strings.Join(topologyStrParts, ",")
+	if tpuSupportTensorNode {
+		// TensorNode TPUs have multi-chiplet (2 per physical chip) architecture
+		topologyStr += ",2"
+	}
+
+	klog.V(1).InfoS("injectTorchTpuEnvs", "Injecting TORCH_TPU_TOPOLOGY", topologyStr)
+	envArrayExists = injectTorchTPUTopology(topologyStr, envPath, patches, envArrayExists)
+
+	// Build TORCH_TPU_SLICEBUILDER_ADDRESSES
+	hostnamesList := strings.Split(hostnames, ",")
+	chipsPerHost := calculateTotalChips(topologyDims) / len(hostnamesList)
+
+	if tpuSupportTensorNode {
+		// TensorNode TPUs have multi-chiplet (2 per physical chip) architecture
+		chipsPerHost *= 2
+	}
+
+	var addresses []string
+	for _, host := range hostnamesList {
+		for i := 0; i < chipsPerHost; i++ {
+			addresses = append(addresses, fmt.Sprintf("%s:%d", host, tpuProcessPortBase+i))
+		}
+	}
+
+	addressesStr := strings.Join(addresses, ",")
+	klog.V(1).InfoS("injectTorchTpuEnvs", "Injecting TORCH_TPU_SLICEBUILDER_ADDRESSES", addressesStr)
+	envArrayExists = injectTorchTPUSlicebuilderAddresses(addressesStr, envPath, patches, envArrayExists)
+
+	return envArrayExists, nil
+}
+
+// injectTorchTPUTopology injects TORCH_TPU_TOPOLOGY into a Pod.
+func injectTorchTPUTopology(topologyStr string, envPath string, patches *[]patch, envArrayExists bool) bool {
+	torchTpuTopology := corev1.EnvVar{
+		Name:  "TORCH_TPU_TOPOLOGY",
+		Value: topologyStr,
+	}
+	*patches, envArrayExists = addEnvVarPatch(*patches, torchTpuTopology, envPath, envArrayExists)
+
+	return envArrayExists
+}
+
+// injectTorchTPUSlicebuilderAddresses injects TORCH_TPU_SLICEBUILDER_ADDRESSES into a Pod.
+func injectTorchTPUSlicebuilderAddresses(addresses string, envPath string, patches *[]patch, envArrayExists bool) bool {
+	torchTpuSlicebuilderAddresses := corev1.EnvVar{
+		Name:  "TORCH_TPU_SLICEBUILDER_ADDRESSES",
+		Value: addresses,
+	}
+	*patches, envArrayExists = addEnvVarPatch(*patches, torchTpuSlicebuilderAddresses, envPath, envArrayExists)
 	return envArrayExists
 }
 
@@ -865,13 +961,14 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					}, path, isEnvInitialized)
 				}
 			}
-			// Network addressing injection logic.
+
+			hostnames := "localhost"
 			if numOfHosts > 1 {
 				// Legacy: inject TPU_WORKER_HOSTNAMES
-				val, _ := getEnvironmentVariable("TPU_WORKER_HOSTNAMES", container)
-				if val == "" || val == "localhost" {
+				hostnames, _ = getEnvironmentVariable("TPU_WORKER_HOSTNAMES", container)
+				if hostnames == "" || hostnames == "localhost" {
 					// Inject value if unset or set to default value.
-					hostnames, err := genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
+					hostnames, err = genDNSHostnames(numOfHosts, groupName, clusterName, namespace, replicaIndex)
 					if err != nil {
 						return nil, err
 					}
@@ -897,6 +994,13 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					}
 				}
 			}
+
+			// Network addressing injection logic.
+			isEnvInitialized, err = injectTorchTpuEnvsIfNeeded(hostnames, pod, container, path, &patches, isEnvInitialized, isV7x)
+			if err != nil {
+				return nil, err
+			}
+
 			// inject TPU_WORKER_ID
 			valWorkerID, _ := getEnvironmentVariable("TPU_WORKER_ID", container)
 			expectedID := fmt.Sprint(finalWorkerID)

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -919,6 +919,99 @@ func Test_InjectHostnames(t *testing.T) {
 	}
 }
 
+func Test_InjectTorchTpuEnvsIfNeeded(t *testing.T) {
+	tests := map[string]struct {
+		clusterName       string
+		groupName         string
+		topology          string
+		accelerator       string
+		hostnames         string
+		initialEnv        []corev1.EnvVar
+		expectedTopology  string
+		expectedAddresses string
+		expectError       bool
+	}{
+		"injectTorchTpuEnvs for multi-host v4": {
+			clusterName:       "test-cluster",
+			groupName:         "test-group",
+			topology:          "2x2x2",
+			accelerator:       "tpu-v4-podslice",
+			hostnames:         "test-group-0-0.test-cluster-headless,test-group-0-1.test-cluster-headless,test-group-0-2.test-cluster-headless,test-group-0-3.test-cluster-headless,test-group-0-4.test-cluster-headless,test-group-0-5.test-cluster-headless,test-group-0-6.test-cluster-headless,test-group-0-7.test-cluster-headless",
+			expectedTopology:  "2,2,2",
+			expectedAddresses: "test-group-0-0.test-cluster-headless:8471,test-group-0-1.test-cluster-headless:8471,test-group-0-2.test-cluster-headless:8471,test-group-0-3.test-cluster-headless:8471,test-group-0-4.test-cluster-headless:8471,test-group-0-5.test-cluster-headless:8471,test-group-0-6.test-cluster-headless:8471,test-group-0-7.test-cluster-headless:8471",
+		},
+		"injectTorchTpuEnvs for multi-host v7x": {
+			clusterName:       "test-cluster",
+			groupName:         "test-group",
+			topology:          "2x2x2",
+			accelerator:       "tpu7x",
+			hostnames:         "test-group-0-0.test-cluster-headless,test-group-0-1.test-cluster-headless,test-group-0-2.test-cluster-headless,test-group-0-3.test-cluster-headless,test-group-0-4.test-cluster-headless,test-group-0-5.test-cluster-headless,test-group-0-6.test-cluster-headless,test-group-0-7.test-cluster-headless",
+			expectedTopology:  "2,2,2,2",
+			expectedAddresses: "test-group-0-0.test-cluster-headless:8471,test-group-0-0.test-cluster-headless:8472,test-group-0-1.test-cluster-headless:8471,test-group-0-1.test-cluster-headless:8472,test-group-0-2.test-cluster-headless:8471,test-group-0-2.test-cluster-headless:8472,test-group-0-3.test-cluster-headless:8471,test-group-0-3.test-cluster-headless:8472,test-group-0-4.test-cluster-headless:8471,test-group-0-4.test-cluster-headless:8472,test-group-0-5.test-cluster-headless:8471,test-group-0-5.test-cluster-headless:8472,test-group-0-6.test-cluster-headless:8471,test-group-0-6.test-cluster-headless:8472,test-group-0-7.test-cluster-headless:8471,test-group-0-7.test-cluster-headless:8472",
+		},
+		"injectTorchTpuEnvs for single-host": {
+			clusterName:       "test-cluster",
+			groupName:         "test-group",
+			topology:          "2x2x1",
+			accelerator:       "tpu-v4-podslice",
+			hostnames:         "localhost",
+			expectedTopology:  "2,2,1",
+			expectedAddresses: "localhost:8471,localhost:8472,localhost:8473,localhost:8474",
+		},
+		"skip injection if TORCH_TPU_TOPOLOGY already exists": {
+			clusterName:      "test-cluster",
+			groupName:        "test-group",
+			topology:         "2x2x2",
+			accelerator:      "tpu-v4-podslice",
+			hostnames:        "test-group-0-0.test-cluster-headless,test-group-0-1.test-cluster-headless",
+			initialEnv:       []corev1.EnvVar{{Name: "TORCH_TPU_TOPOLOGY", Value: "already-set"}},
+			expectedTopology: "", // No patch expected
+		},
+		"fail on invalid topology": {
+			clusterName: "test-cluster",
+			groupName:   "test-group",
+			topology:    "invalid",
+			accelerator: "tpu-v4-podslice",
+			hostnames:   "test-group-0-0.test-cluster-headless",
+			expectError: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			testPod := getTestTPUWorker(tc.clusterName, tc.groupName, "test-namespace", tc.accelerator, tc.topology, "4")
+			if tc.initialEnv != nil {
+				testPod.Spec.Containers[0].Env = tc.initialEnv
+			}
+			patches := []patch{}
+			
+			_, err := injectTorchTpuEnvsIfNeeded(tc.hostnames, testPod, testPod.Spec.Containers[0], "/spec/containers/0/env", &patches, len(testPod.Spec.Containers[0].Env) > 0, strings.HasPrefix(tc.accelerator, "tpu7x"))
+			
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			
+			if tc.expectedTopology != "" {
+				if assert.GreaterOrEqual(t, len(patches), 2) {
+					// Check TOPOLOGY patch
+					assert.Equal(t, "/spec/containers/0/env", patches[0]["path"])
+					expectedTopoEnv := []corev1.EnvVar{{Name: "TORCH_TPU_TOPOLOGY", Value: tc.expectedTopology}}
+					assert.Equal(t, expectedTopoEnv, patches[0]["value"])
+					
+					// Check SLICEBUILDER_ADDRESSES patch
+					assert.Equal(t, "/spec/containers/0/env/-", patches[1]["path"])
+					expectedAddrEnv := corev1.EnvVar{Name: "TORCH_TPU_SLICEBUILDER_ADDRESSES", Value: tc.expectedAddresses}
+					assert.Equal(t, expectedAddrEnv, patches[1]["value"])
+				}
+			} else {
+				assert.Equal(t, 0, len(patches), "Expected no patches")
+			}
+		})
+	}
+}
+
 func Test_InjectSubdomain(t *testing.T) {
 	tests := map[string]struct {
 		clusterName       string


### PR DESCRIPTION
inject Torch TPU environment variables:

1. TORCH_TPU_SLICEBUILDER_ADDRESSES (comma-separated list of address:port pairs for all workers)
2. TORCH_TPU_TOPOLOGY (describing the TPU mesh, e.g., "2,2,2")
