### PR TITLE
[e2e][Test] Add JAX/XLA distributed init and Ray Core TPU utilities integration tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -33,7 +33,16 @@ export REGION=us-central2
 export ZONE=us-central2-b
 ```
 
-### 2. Provision and Test
+### 2. Configuring Custom Ray Docker Images (Optional)
+By default, the E2E test suite uses the official **`rayproject/ray:nightly-tpu`** image to test the webhook with the latest Ray builds.
+
+You can easily override this to test a custom Ray image (or a specific version) by setting the `RAY_IMAGE` environment variable before running the suite:
+```bash
+# Example: Test a custom local or private registry image
+export RAY_IMAGE="rayproject/ray:2.35.0-py310-tpu"
+```
+
+### 3. Provision and Test
 Run the wrapper script with `--setup` to spin up the custom VPC, the GKE cluster, `cert-manager`, and the webhook:
 ```bash
 ./scripts/run-e2e.sh --setup

--- a/e2e/manifests/v6e/v6e-integration-tpu-utils.yaml
+++ b/e2e/manifests/v6e/v6e-integration-tpu-utils.yaml
@@ -1,0 +1,35 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v6e-integration
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:nightly-tpu
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 2
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:nightly-tpu
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+          cloud.google.com/gke-tpu-topology: 2x4

--- a/e2e/webhook/tpu_logging.py
+++ b/e2e/webhook/tpu_logging.py
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+
+def setup_tpu_logging(logger_name: str) -> logging.Logger:
+  """Configures standard logging to stdout with structured formatting for E2E TPU workloads."""
+  logging.basicConfig(
+      level=logging.INFO,
+      format="%(levelname)s: %(message)s",
+      handlers=[logging.StreamHandler(sys.stdout)],
+  )
+  return logging.getLogger(logger_name)

--- a/e2e/webhook/tpu_pod_mutation_test.go
+++ b/e2e/webhook/tpu_pod_mutation_test.go
@@ -61,6 +61,7 @@ const (
 
 	// Ray-specific labels.
 	rayNodeTypeWorker   = string(rayv1.WorkerNode)
+	rayNodeTypeHead     = string(rayv1.HeadNode)
 )
 
 func init() {
@@ -674,7 +675,7 @@ func TestWebhookMutation_V6eDNSResolution(t *testing.T) {
 
 	// Wait for all worker pods to be in Running phase so DNS endpoints are fully registered
 	t.Log("Waiting for all worker pods to reach Running phase...")
-	err = wait.PollUntilContextTimeout(t.Context(), 3*time.Second, 120*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(t.Context(), 5*time.Second, 240*time.Second, true, func(ctx context.Context) (bool, error) {
 		currentPods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			return false, err
@@ -765,6 +766,82 @@ func execCommandInPod(t *testing.T, podName string, containerName string, cmd []
 	return stdout.String(), stderr.String(), err
 }
 
+func writeLocalFileToPod(t *testing.T, podName string, containerName string, localPath string, remotePath string) {
+	t.Helper()
+	content, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("Failed to read local file %s: %v", localPath, err)
+	}
+	t.Logf("Writing local file %s to %s in pod %s...", localPath, remotePath, podName)
+	cmd := []string{"bash", "-c", "cat << 'EOF' > " + remotePath + "\n" + string(content) + "\nEOF\n"}
+	stdout, stderr, err := execCommandInPod(t, podName, containerName, cmd)
+	if err != nil {
+		t.Fatalf("Failed to write file %s to pod: %v (stdout: %q, stderr: %q)", remotePath, err, stdout, stderr)
+	}
+}
+
+func waitForHeadPodRunning(t *testing.T, clusterName string, timeout time.Duration) *corev1.Pod {
+	t.Helper()
+	t.Logf("Waiting for head pod of cluster %s to reach Running phase...", clusterName)
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
+	var headPod *corev1.Pod
+	err := wait.PollUntilContextTimeout(t.Context(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+		for _, p := range pods.Items {
+			if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeHead && p.Status.Phase == corev1.PodRunning {
+				headPod = &p
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Head pod of cluster %s failed to reach Running phase within %v: %v", clusterName, timeout, err)
+	}
+	return headPod
+}
+
+func waitForAllPodsRunning(t *testing.T, clusterName string, expectedWorkerCount int, timeout time.Duration) {
+	t.Helper()
+	t.Logf("Waiting for head pod and all %d worker pods of cluster %s to reach Running phase...", expectedWorkerCount, clusterName)
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
+	err := wait.PollUntilContextTimeout(t.Context(), 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+
+		headRunning := false
+		workerRunningCount := 0
+		for _, p := range pods.Items {
+			if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeHead && p.Status.Phase == corev1.PodRunning {
+				headRunning = true
+			} else if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+				if p.Status.Phase == corev1.PodRunning {
+					containerRunning := false
+					for _, cs := range p.Status.ContainerStatuses {
+						if cs.Name == p.Spec.Containers[0].Name && cs.State.Running != nil {
+							containerRunning = true
+							break
+						}
+					}
+					if containerRunning {
+						workerRunningCount++
+					}
+				}
+			}
+		}
+		t.Logf("Checking pod states... Head Running: %t, Workers Running: %d/%d", headRunning, workerRunningCount, expectedWorkerCount)
+		return headRunning && workerRunningCount == expectedWorkerCount, nil
+	})
+	if err != nil {
+		t.Fatalf("Pods of cluster %s failed to reach Running phase within %v: %v", clusterName, timeout, err)
+	}
+}
+
 func triggerRayClusterReconcile(t *testing.T, clusterName string) {
 	t.Helper()
 	gvr := schema.GroupVersionResource{
@@ -838,3 +915,29 @@ func waitForRecreatedPods(t *testing.T, labelSelector string, expectedCount int,
 	}
 	return recreatedPods
 }
+
+func TestWebhookIntegration_RayTPUUtilsAndJAX(t *testing.T) {
+	clusterName := "tpu-v6e-integration"
+
+	// Wait for head pod and both TPU worker pods to reach Running phase
+	waitForAllPodsRunning(t, clusterName, 2, 240*time.Second)
+
+	// Retrieve head pod reference to execute commands inside it
+	headPod := waitForHeadPodRunning(t, clusterName, 10*time.Second)
+
+	// Write utility logging configuration and verification script into the head pod
+	writeLocalFileToPod(t, headPod.Name, headPod.Spec.Containers[0].Name, "tpu_logging.py", "/tmp/tpu_logging.py")
+	writeLocalFileToPod(t, headPod.Name, headPod.Spec.Containers[0].Name, "verify_tpu_utils.py", "/tmp/verify_tpu_utils.py")
+
+	// Execute verify_tpu_utils.py via Python inside the head pod
+	t.Log("Running verify_tpu_utils.py E2E verification workload...")
+	runCmd := []string{"python3", "/tmp/verify_tpu_utils.py"}
+	stdout, stderr, err := execCommandInPod(t, headPod.Name, headPod.Spec.Containers[0].Name, runCmd)
+	if err != nil {
+		t.Fatalf("TPU utilities and JAX verification failed: %v (stdout: %q, stderr: %q)", err, stdout, stderr)
+	}
+
+	t.Logf("Execution output:\n%s", stdout)
+	assert.Contains(t, stdout, "All Ray core TPU utilities and JAX/XLA distributed inits verified successfully.")
+}
+

--- a/e2e/webhook/verify_tpu_utils.py
+++ b/e2e/webhook/verify_tpu_utils.py
@@ -1,0 +1,261 @@
+import logging
+import math
+import os
+from typing import Any, Dict, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import ray
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+import ray.util.tpu as ray_tpu
+from tpu_logging import setup_tpu_logging
+
+NUM_WORKERS_MULTIPLIER = 4
+
+logger = setup_tpu_logging("verify_tpu_utils")
+
+
+def discover_tpu_topology_info(
+    nodes: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any], str, str]:
+  """Discovers and parses active TPU node metadata from Ray GCS nodes database."""
+  tpu_nodes = [
+      n
+      for n in nodes
+      if n.get("Alive") and n.get("Resources", {}).get("TPU", 0) > 0
+  ]
+  if not tpu_nodes:
+    raise RuntimeError("No active TPU nodes discovered in the Ray cluster.")
+
+  first_node = tpu_nodes[0]
+  labels = first_node.get("Labels", {})
+  topology = labels.get("ray.io/tpu-topology")
+  accelerator_type = labels.get("ray.io/accelerator-type")
+
+  if not topology or not accelerator_type:
+    raise RuntimeError(
+        f"Missing required TPU GCS topology labels in node: {first_node}"
+    )
+
+  return tpu_nodes, first_node, topology, accelerator_type
+
+
+# Define remote task to run JAX on physical worker nodes
+@ray.remote(num_cpus=0)
+def verify_tpu_hardware_and_env(
+    expected_global_devices,
+    expected_local_devices,
+    expected_worker_count,
+    expected_chips_per_node,
+):
+  """Verifies GKE TPU environment values, JAX distribution mesh init, and runs math on TPUs."""
+  required_envs = [
+      "TPU_NAME",
+      "TPU_WORKER_ID",
+  ]
+  env_values = {}
+  for env in required_envs:
+    val = os.environ.get(env)
+    assert val is not None, (
+        f"Missing required env: {env} on TPU worker"
+    )
+    env_values[env] = val
+
+  # Verify JAX Distributed Initialization and XLA Matrix Multiplication on
+  # physical TPU
+  jax.distributed.initialize()
+  device_count = jax.device_count()
+  local_device_count = jax.local_device_count()
+  assert device_count == expected_global_devices, (
+      f"Expected {expected_global_devices} global JAX devices, "
+      f"got {device_count}"
+  )
+  assert local_device_count == expected_local_devices, (
+      f"Expected {expected_local_devices} local JAX devices, "
+      f"got {local_device_count}"
+  )
+
+  # Perform math operation on physical TPU to verify XLA JIT & PJRT pipeline
+  # works
+  x = jax.random.normal(
+      jax.random.PRNGKey(0), (2048, 2048), dtype=jnp.bfloat16
+  )
+  y = jax.random.normal(
+      jax.random.PRNGKey(1), (2048, 2048), dtype=jnp.bfloat16
+  )
+  z = jnp.matmul(x, y)
+  z.block_until_ready()
+
+  # Verify ray.util.tpu getters inside the TPU node container
+  pod_name = ray_tpu.get_current_pod_name()
+  worker_count = ray_tpu.get_current_pod_worker_count()
+  num_chips = ray_tpu.get_num_tpu_chips_on_node()
+  assert (
+      pod_name is not None
+  ), "get_current_pod_name returned None inside TPU Pod"
+  assert (
+      worker_count == expected_worker_count
+  ), f"Expected {expected_worker_count} workers in pod, got {worker_count}"
+  assert (
+      num_chips == expected_chips_per_node
+  ), f"Expected {expected_chips_per_node} TPU chips per node, got {num_chips}"
+
+  return pod_name, env_values
+
+
+def main():
+  logger.info("1. Initializing Ray Client...")
+  ray.init()
+
+  logger.info("Discovering cluster topology dynamically from Ray...")
+  nodes = ray.nodes()
+  logger.info("  Ray Nodes GCS database: %s", nodes)
+
+  (
+      tpu_nodes,
+      first_node,
+      topology,
+      accelerator_type,
+  ) = discover_tpu_topology_info(nodes)
+
+  # 1. Test get_tpu_version_from_type utility
+  tpu_version = ray_tpu.get_tpu_version_from_type(accelerator_type)
+  logger.info("Discovered Topology: %s", topology)
+  logger.info(
+      "Discovered Accelerator Type: %s (clean version: %s)",
+      accelerator_type,
+      tpu_version,
+  )
+
+  # Extract chips capacity from node resources
+  expected_chips_per_node = int(first_node.get("Resources", {}).get("TPU", 4))
+
+  # 2. Test get_tpu_worker_resources calculator passing GKE chips override
+  hosts_per_slice, _ = ray_tpu.get_tpu_worker_resources(
+      topology=topology,
+      accelerator_type=tpu_version,
+      chips_per_vm=expected_chips_per_node,
+  )
+  expected_worker_count = len(tpu_nodes)
+  expected_global_devices = expected_worker_count * expected_chips_per_node
+  expected_local_devices = expected_chips_per_node
+
+  logger.info("Discovered Chips Per Node: %s", expected_chips_per_node)
+  logger.info("Discovered Worker Count: %s", expected_worker_count)
+  logger.info("Discovered Hosts Per Slice: %s", hosts_per_slice)
+
+  # 3. Test node helper utilities
+  first_slice_name = ray_tpu.get_tpu_slice_name_from_node(first_node)
+  assert (
+      first_slice_name is not None
+  ), "get_tpu_slice_name_from_node returned None for active TPU node"
+  slice_nodes = ray_tpu.get_tpu_nodes_for_slice(first_slice_name, nodes=nodes)
+  assert (
+      len(slice_nodes) == hosts_per_slice
+  ), f"Expected {hosts_per_slice} slice nodes, got {len(slice_nodes)}"
+  logger.info(
+      "  Verified TPU slice name: %s containing nodes: %s",
+      first_slice_name,
+      [n["NodeName"] for n in slice_nodes],
+  )
+
+  # 4. Test coordinator environment variable builder
+  coordinator_envs = ray_tpu.get_tpu_coordinator_env_vars(
+      coordinator_address="10.128.0.2",
+      num_slices=2,
+      slice_id=1,
+      coordinator_port="9090",
+  )
+  assert coordinator_envs["MEGASCALE_COORDINATOR_ADDRESS"] == "10.128.0.2"
+  assert coordinator_envs["MEGASCALE_PORT"] == "9090"
+  assert coordinator_envs["MEGASCALE_NUM_SLICES"] == "2"
+  assert coordinator_envs["MEGASCALE_SLICE_ID"] == "1"
+  logger.info("  Verified coordinator environment variable generator.")
+
+  logger.info("2. Verifying ray.util.tpu query functions...")
+  ready_slices = ray_tpu.get_num_ready_tpu_slices(
+      topology=topology, accelerator_type=tpu_version
+  )
+  total_slices = ray_tpu.get_num_tpu_slices(
+      topology=topology, accelerator_type=tpu_version
+  )
+  logger.info("  Ready Slices (Idle): %s", ready_slices)
+  logger.info("  Total Slices (Intact): %s", total_slices)
+  assert (
+      total_slices >= 1
+  ), f"Expected at least 1 intact slice, got {total_slices}"
+
+  # Test helper calculators
+  num_slices_calc = ray_tpu.get_tpu_num_slices_for_workers(
+      topology=topology,
+      accelerator_type=tpu_version,
+      num_workers=NUM_WORKERS_MULTIPLIER,
+  )
+  expected_slices = math.ceil(NUM_WORKERS_MULTIPLIER / hosts_per_slice)
+  logger.info(
+      "  Calculated slices required for %s workers: %s (expected: %s)",
+      NUM_WORKERS_MULTIPLIER,
+      num_slices_calc,
+      expected_slices,
+  )
+  assert num_slices_calc in (expected_slices, NUM_WORKERS_MULTIPLIER), (
+      f"Unexpected slices count: {num_slices_calc}, "
+      f"expected {expected_slices} or fallback {NUM_WORKERS_MULTIPLIER}"
+  )
+
+  logger.info("3. Reserving SlicePlacementGroup dynamically...")
+  # Use the slice_placement_group API to provision the TPU slice
+  pg_handle = ray_tpu.slice_placement_group(
+      topology=topology,
+      accelerator_version=tpu_version,
+      chips_per_vm=expected_chips_per_node,
+  )
+  slice_pg = pg_handle.placement_group
+
+  logger.info("  Waiting for slice placement group to become ready...")
+  ray.get(slice_pg.ready(), timeout=30)
+  logger.info("  SlicePlacementGroup is ready.")
+
+  # Dispatch validation tasks concurrently to each worker host in the
+  # placement group
+  tasks = [
+      verify_tpu_hardware_and_env.options(
+          resources={"TPU": expected_chips_per_node},
+          scheduling_strategy=PlacementGroupSchedulingStrategy(
+              placement_group=slice_pg, placement_group_bundle_index=i
+          ),
+      ).remote(
+          expected_global_devices,
+          expected_local_devices,
+          expected_worker_count,
+          expected_chips_per_node,
+      )
+      for i in range(pg_handle.num_hosts)
+  ]
+  results = ray.get(tasks)
+  logger.info(
+      "  Scheduled tasks returned results from physical TPU worker hosts: %s",
+      results,
+  )
+
+  for name, envs in results:
+    logger.info("  Verified Host: %s", name)
+    for k, v in envs.items():
+      logger.info("    %s = %s", k, v)
+
+  logger.info("4. Releasing head reservation placement groups...")
+  pg_handle.release_head_pgs()
+  logger.info("  Head placement groups released cleanly.")
+
+  logger.info("5. Shutting down worker placement group...")
+  pg_handle.shutdown()
+  logger.info("  Worker placement group released cleanly.")
+
+  logger.info(
+      "All Ray core TPU utilities and JAX/XLA distributed inits verified"
+      " successfully."
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/samples/tpu-test.py
+++ b/samples/tpu-test.py
@@ -1,19 +1,22 @@
 import ray
 
+
 @ray.remote(resources={"TPU": 4})
 def tpu_cores():
-    import jax
+  import jax
 
-    print("TPU cores:" + str(jax.device_count()))
-    return "TPU cores:" + str(jax.device_count())
+  print("TPU cores:" + str(jax.device_count()))
+  return "TPU cores:" + str(jax.device_count())
 
 
 ray.init(
     runtime_env={
         "pip": [
             "jax[tpu]",
-            "-f https://storage.googleapis.com/jax-releases/libtpu_releases.html",
-            "ml_dtypes==0.2.0"
+            (
+                "-f https://storage.googleapis.com/jax-releases/libtpu_releases.html"
+            ),
+            "ml_dtypes==0.2.0",
         ]
     }
 )

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -86,7 +86,7 @@ cat e2e/manifests/v7x/v7x-8-single-host.yaml | sed "s|rayproject/ray:nightly-tpu
 cat e2e/manifests/v7x/v7x-multi-container.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Validation, Single-Host, & Multi-Container E2E tests (Group 1)..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation|TestWebhookMutation_HeterogeneousCluster|TestWebhookMutation_V7xSingleHost|TestWebhookMutation_V7xMultiContainer"
+go test -tags=e2e -count=1 -v ./e2e/webhook/... -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation|TestWebhookMutation_HeterogeneousCluster|TestWebhookMutation_V7xSingleHost|TestWebhookMutation_V7xMultiContainer"
 GROUP1_EXIT=$?
 set -e
 echo "Cleaning up Validation, Single-Host, & Multi-Container manifests..."
@@ -108,7 +108,7 @@ cat e2e/manifests/v6e/v6e-16-multi-host.yaml | sed "s|rayproject/ray:nightly-tpu
 cat e2e/manifests/v7x/v7x-16-multi-host.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Multi-Host, DNS, & Pod Churn E2E tests (Group 2)..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice|TestWebhookMutation_V6eDNSResolution|TestWebhookMutation_V7xMultiHost"
+go test -tags=e2e -count=1 -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice|TestWebhookMutation_V6eDNSResolution|TestWebhookMutation_V7xMultiHost"
 GROUP2_EXIT=$?
 set -e
 echo "Cleaning up Multi-Host manifests..."
@@ -128,7 +128,7 @@ cat e2e/manifests/v6e/v6e-16-multi-slice.yaml | sed "s|rayproject/ray:nightly-tp
 cat e2e/manifests/v7x/v7x-16-multi-slice.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Multi-Slice (Megascale) & Multi-Slice Churn E2E tests (Group 3)..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice|TestWebhookMutation_V7xMultiSlice"
+go test -tags=e2e -count=1 -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice|TestWebhookMutation_V7xMultiSlice"
 GROUP3_EXIT=$?
 set -e
 echo "Cleaning up Multi-Slice manifests..."
@@ -136,6 +136,24 @@ kubectl delete -f e2e/manifests/v6e/v6e-16-multi-slice.yaml -n "$NAMESPACE" --ig
 kubectl delete -f e2e/manifests/v7x/v7x-16-multi-slice.yaml -n "$NAMESPACE" --ignore-not-found=true || true
 if [ $GROUP3_EXIT -ne 0 ]; then
     TEST_EXIT_CODE=$GROUP3_EXIT
+fi
+
+# Wait to allow TPU device plugin hardware state synchronization
+echo "Waiting 10 seconds for TPU hardware resource detransitions..."
+sleep 10
+
+# 4. Run JAX/XLA and Ray Core TPU Utilities Integration tests
+echo "Deploying JAX & Ray Core Utilities E2E integration manifests inside namespace $NAMESPACE..."
+cat e2e/manifests/v6e/v6e-integration-tpu-utils.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+set +e
+echo "Running JAX/XLA & Ray Core TPU Utilities E2E tests (Group 4)..."
+go test -tags=e2e -count=1 -v ./e2e/webhook/... -run "TestWebhookIntegration_RayTPUUtilsAndJAX"
+GROUP4_EXIT=$?
+set -e
+echo "Cleaning up JAX & Ray Core Utilities manifests..."
+kubectl delete -f e2e/manifests/v6e/v6e-integration-tpu-utils.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+if [ $GROUP4_EXIT -ne 0 ]; then
+    TEST_EXIT_CODE=$GROUP4_EXIT
 fi
 
 # Clean up dynamic isolated test namespace


### PR DESCRIPTION
This PR adds an e2e integration test suite running on physical GKE TPU hardware to verify environment injection, JAX distributed coordinator mesh initialization, PJRT hardware operations, and the [ray.util.tpu](https://github.com/ray-project/ray/blob/66ac79dabcbba53d7d702c4a4086da39de073bba/python/ray/util/tpu.py#L4) helper utilities - most importantly the `SlicePlacementGroup` API.

Specific Changes:
- Add `verify_tpu_utils.py` to assert correct `TPU_NAME`/`TPU_WORKER_ID` injection from the Ray nodes, initialize distributed JAX, run real matrix math on hardware, and assert `ray.util.tpu` utility functions run as expected (i.e. can provision a slice with a `SlicePlacementGroup` and run a JAX workload on it).
- Add `v6e-integration-tpu-utils.yaml` manifest for a 2-host TPU v6e integration test slice.
- Update E2E Go tests to write the python test script dynamically into the running pod and then wait for completion / logs
- Add  pod running/readiness wait helper to prevent race conditions during distributed node registration in Ray GCS.