### PR TITLE
[e2e][Test] Add V7x (Ironwood) TPU support, validation tests, and namespace isolation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,20 +1,28 @@
 # E2E Mutation & Validation Tests for KubeRay TPU Webhook
 
-This directory contains end-to-end (E2E) qualification and mutation tests to validate that the KubeRay TPU webhook correctly injects TPU-specific environment variables, labels, and hostnames on GKE TPU workloads.
+This directory contains end-to-end (E2E) qualification, mutation, and validation tests to ensure that the KubeRay TPU webhook correctly injects TPU-specific environment variables, labels, hostnames, and enforces topology validations on GKE TPU workloads.
 
 ---
 
 ## Prerequisites
 
 1.  **Tools**: Install `gcloud`, `kubectl`, and Go `1.25+`.
-2.  **GCP Project & Quota**: A GCP project with sufficient TPU quota for **v6e** in `us-central2-b`.
-3.  **Permissions**: IAM permissions to create clusters, networks, subnetworks, firewalls, and node pools.
+2.  **GCP Project & Quotas**: A GCP project with sufficient TPU quotas for **v6e** and **tpu7x** in `us-central2-b`.
+3.  **Permissions**: IAM permissions to manage cluster networks, subnetworks, firewalls, and node pools.
+
+---
+
+## Dynamic Namespace Isolation
+
+To prevent ongoing test runs from conflicting or locking physical TPU resources, the E2E runner automatically allocates a unique, isolated test namespace (e.g. `test-ns-tfx7i`) for every run. 
+
+When the suite completes, it deletes the dynamic namespace to fully release the physical hardware and clean up cluster resources.
 
 ---
 
 ## Quick Start: Fully Automated Suite
 
-Use this workflow if you want the framework to automatically provision a GKE cluster, set up resources, run mutation tests, and tear down when finished.
+Use this workflow if you want the framework to automatically provision a GKE cluster, configure resources, run tests, and tear down when finished.
 
 ### 1. Configure Environment
 Define your project and regional preferences:
@@ -26,11 +34,11 @@ export ZONE=us-central2-b
 ```
 
 ### 2. Provision and Test
-Run the wrapper script with `--setup` to spin up the custom VPC, the GKE cluster with `n2-standard-8` head nodes, a spot `v6e-16` TPU slice node pool, `cert-manager`, and the webhook:
+Run the wrapper script with `--setup` to spin up the custom VPC, the GKE cluster, `cert-manager`, and the webhook:
 ```bash
 ./scripts/run-e2e.sh --setup
 ```
-This will provision the infrastructure, register the webhook mutation controllers, apply manifests, and execute the Go test suite.
+This provisions the cluster infrastructure, registers the webhook controllers, applies the test manifests, and executes all tests in logical groups.
 
 ### 3. Clean Up
 To prevent ongoing GCP charges after testing:
@@ -42,51 +50,48 @@ To prevent ongoing GCP charges after testing:
 
 ## Manual Verification: Pre-existing Cluster
 
-Use this workflow if you already have a running GKE cluster with the KubeRay TPU webhook active and simply want to trigger mutation verification.
+Use this workflow if you already have a running GKE cluster with the KubeRay TPU webhook active and want to run individual tests manually.
 
 ### 1. Deploy Manifests
-Apply the RayCluster manifests to the cluster to initiate the mutating admission processes:
+Apply the RayCluster manifests to a specific namespace (e.g. `test-namespace`) to initiate mutation:
 ```bash
-kubectl apply -f e2e/manifests/v6e/v6e-8-single-host.yaml
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-host.yaml
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-slice.yaml
+# For V6e TPUs:
+kubectl apply -f e2e/manifests/v6e/v6e-8-single-host.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v6e/v6e-16-multi-host.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v6e/v6e-16-multi-slice.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v6e/heterogeneous-cluster.yaml -n test-namespace
+
+# For V7x TPUs:
+kubectl apply -f e2e/manifests/v7x/v7x-8-single-host.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v7x/v7x-16-multi-host.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v7x/v7x-16-multi-slice.yaml -n test-namespace
+kubectl apply -f e2e/manifests/v7x/v7x-multi-container.yaml -n test-namespace
 ```
 
 ### 2. Run Assertions
-You can trigger the entire test suite via the root Makefile:
+Run the entire test suite via:
 ```bash
+export TEST_NAMESPACE=test-namespace
 make e2e
 ```
-Or navigate to the test directory and target individual verification scenarios:
+
+Or target specific test groups and scenarios directly:
+
 ```bash
 cd e2e/webhook
 
-# Run Single-Host mutation tests
-go test -v -run TestWebhookMutation_V6eSingleHost
+# Validation, Single-Host, & Multi-Container E2E tests (Group 1)
+go test -v -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation|TestWebhookMutation_HeterogeneousCluster|TestWebhookMutation_V7xSingleHost|TestWebhookMutation_V7xMultiContainer"
 
-# Run Multi-Host mutation tests
-go test -v -run TestWebhookMutation_V6eMultiHost
+# Multi-Host, DNS, & Pod Churn E2E tests (Group 2)
+go test -v -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice|TestWebhookMutation_V6eDNSResolution|TestWebhookMutation_V7xMultiHost"
 
-# Run Megascale Multi-Slice mutation tests
-go test -v -run TestWebhookMutation_V6eMultiSlice
-
-# Run Single-Slice Pod Churn qualification tests (concurrently deletes 2 pods)
-go test -v -run TestWebhookMutation_V6ePodChurnSingleSlice
-
-# Run Multi-Slice Pod Churn qualification tests (concurrently deletes 4 pods across slices)
-go test -v -run TestWebhookMutation_V6ePodChurnMultiSlice
-
-# Run all Validating Webhook tests for RayClusters requesting TPUs
-go test -v -run TestRayClusterValidation
+# Multi-Slice (Megascale) & Multi-Slice Churn E2E tests (Group 3)
+go test -v -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice|TestWebhookMutation_V7xMultiSlice"
 ```
 
 ### 3. Clean Up
-After tests complete, clean up the deployed mutation test fixtures:
+Delete the test fixtures when finished:
 ```bash
-kubectl delete -f e2e/manifests/v6e/v6e-8-single-host.yaml --ignore-not-found=true || true
-kubectl delete -f e2e/manifests/v6e/v6e-16-multi-host.yaml --ignore-not-found=true || true
-kubectl delete -f e2e/manifests/v6e/v6e-16-multi-slice.yaml --ignore-not-found=true || true
+kubectl delete ns test-namespace
 ```
-
-
-

--- a/e2e/manifests/invalid/invalid-num-of-hosts-omitted.yaml
+++ b/e2e/manifests/invalid/invalid-num-of-hosts-omitted.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -23,7 +23,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "4"

--- a/e2e/manifests/invalid/invalid-num-of-hosts-omitted.yaml
+++ b/e2e/manifests/invalid/invalid-num-of-hosts-omitted.yaml
@@ -1,0 +1,34 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v6e-invalid-hosts-omitted
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+          cloud.google.com/gke-tpu-topology: 4x4

--- a/e2e/manifests/invalid/invalid-num-of-hosts-zero.yaml
+++ b/e2e/manifests/invalid/invalid-num-of-hosts-zero.yaml
@@ -1,0 +1,35 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v6e-invalid-hosts-zero
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 0
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+          cloud.google.com/gke-tpu-topology: 4x4

--- a/e2e/manifests/invalid/invalid-num-of-hosts-zero.yaml
+++ b/e2e/manifests/invalid/invalid-num-of-hosts-zero.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "4"

--- a/e2e/manifests/invalid/invalid-topology.yaml
+++ b/e2e/manifests/invalid/invalid-topology.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "8"

--- a/e2e/manifests/v6e/heterogeneous-cluster.yaml
+++ b/e2e/manifests/v6e/heterogeneous-cluster.yaml
@@ -1,0 +1,51 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v6e-heterogeneous
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 1
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "8"
+            limits:
+              google.com/tpu: "8"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+          cloud.google.com/gke-tpu-topology: 2x4
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: cpu-worker-group
+    template:
+      spec:
+        containers:
+        - name: ray-worker-cpu
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "2"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"

--- a/e2e/manifests/v6e/heterogeneous-cluster.yaml
+++ b/e2e/manifests/v6e/heterogeneous-cluster.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "8"
@@ -41,7 +41,7 @@ spec:
       spec:
         containers:
         - name: ray-worker-cpu
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "2"

--- a/e2e/manifests/v6e/v6e-16-multi-host.yaml
+++ b/e2e/manifests/v6e/v6e-16-multi-host.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "4"

--- a/e2e/manifests/v6e/v6e-16-multi-slice.yaml
+++ b/e2e/manifests/v6e/v6e-16-multi-slice.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           env:
           - name: MEGASCALE_NUM_SLICES
             value: "2"

--- a/e2e/manifests/v6e/v6e-8-single-host.yaml
+++ b/e2e/manifests/v6e/v6e-8-single-host.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "8"

--- a/e2e/manifests/v7x/v7x-16-multi-host.yaml
+++ b/e2e/manifests/v7x/v7x-16-multi-host.yaml
@@ -1,0 +1,35 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v7x-multi-host
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 2
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu7x
+          cloud.google.com/gke-tpu-topology: 2x2x2

--- a/e2e/manifests/v7x/v7x-16-multi-host.yaml
+++ b/e2e/manifests/v7x/v7x-16-multi-host.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "4"

--- a/e2e/manifests/v7x/v7x-16-multi-slice.yaml
+++ b/e2e/manifests/v7x/v7x-16-multi-slice.yaml
@@ -1,0 +1,38 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v7x-multi-slice
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 2
+    minReplicas: 2
+    maxReplicas: 2
+    groupName: tpu-worker-group
+    numOfHosts: 2
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          env:
+          - name: MEGASCALE_NUM_SLICES
+            value: "2"
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu7x
+          cloud.google.com/gke-tpu-topology: 2x2x2

--- a/e2e/manifests/v7x/v7x-16-multi-slice.yaml
+++ b/e2e/manifests/v7x/v7x-16-multi-slice.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           env:
           - name: MEGASCALE_NUM_SLICES
             value: "2"

--- a/e2e/manifests/v7x/v7x-8-single-host.yaml
+++ b/e2e/manifests/v7x/v7x-8-single-host.yaml
@@ -1,0 +1,35 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v7x-single-host
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 1
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "4"
+            limits:
+              google.com/tpu: "4"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu7x
+          cloud.google.com/gke-tpu-topology: 2x2x1

--- a/e2e/manifests/v7x/v7x-8-single-host.yaml
+++ b/e2e/manifests/v7x/v7x-8-single-host.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,7 +24,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "4"

--- a/e2e/manifests/v7x/v7x-multi-container.yaml
+++ b/e2e/manifests/v7x/v7x-multi-container.yaml
@@ -1,0 +1,42 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: tpu-v7x-multi-container
+spec:
+  headGroupSpec:
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              cpu: "1"
+            limits:
+              cpu: "1"
+  workerGroupSpecs:
+  - replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    groupName: tpu-worker-group
+    numOfHosts: 1
+    template:
+      spec:
+        containers:
+        - name: ray-worker-0
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "2"
+            limits:
+              google.com/tpu: "2"
+        - name: ray-worker-1
+          image: rayproject/ray:2.55.0
+          resources:
+            requests:
+              google.com/tpu: "2"
+            limits:
+              google.com/tpu: "2"
+        nodeSelector:
+          cloud.google.com/gke-tpu-accelerator: tpu7x
+          cloud.google.com/gke-tpu-topology: 2x2x1

--- a/e2e/manifests/v7x/v7x-multi-container.yaml
+++ b/e2e/manifests/v7x/v7x-multi-container.yaml
@@ -8,7 +8,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               cpu: "1"
@@ -24,14 +24,14 @@ spec:
       spec:
         containers:
         - name: ray-worker-0
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "2"
             limits:
               google.com/tpu: "2"
         - name: ray-worker-1
-          image: rayproject/ray:2.55.0
+          image: rayproject/ray:nightly-tpu
           resources:
             requests:
               google.com/tpu: "2"

--- a/e2e/webhook/tpu_pod_mutation_test.go
+++ b/e2e/webhook/tpu_pod_mutation_test.go
@@ -2,8 +2,8 @@
 
 package webhook
 
-
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -11,46 +11,91 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
 )
 
 var (
 	kubeconfig    *string
 	clientset     kubernetes.Interface
 	dynamicClient dynamic.Interface
+	restConfig    *rest.Config
+	testNamespace = "default"
+)
+
+const (
+	// TPU webhook environment variable names.
+	tpuWorkerIDEnv           = "TPU_WORKER_ID"
+	tpuNameEnv               = "TPU_NAME"
+	tpuDevicePluginHostIPEnv = "TPU_DEVICE_PLUGIN_HOST_IP"
+	tpuDevicePluginAddrEnv   = "TPU_DEVICE_PLUGIN_ADDR"
+	tpuWorkerHostnamesEnv    = "TPU_WORKER_HOSTNAMES"
+	tpuProcessAddressesEnv   = "TPU_PROCESS_ADDRESSES"
+	tpuProcessPortEnv        = "TPU_PROCESS_PORT"
+
+	// Megascale environment variable names.
+	megascaleSliceIDEnv            = "MEGASCALE_SLICE_ID"
+	megascaleCoordinatorAddressEnv = "MEGASCALE_COORDINATOR_ADDRESS"
+	megascalePortEnv               = "MEGASCALE_PORT"
+
+	// GKE TPU-specific labels.
+	replicaIndexLabelKey = "replicaIndex"
+
+	// Ray-specific labels.
+	rayNodeTypeWorker   = string(rayv1.WorkerNode)
 )
 
 func init() {
-	if home := os.Getenv("HOME"); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	if flag.Lookup("kubeconfig") == nil {
+		if home := os.Getenv("HOME"); home != "" {
+			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		} else {
+			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+		}
 	}
 }
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if ns := os.Getenv("TEST_NAMESPACE"); ns != "" {
+		testNamespace = ns
+	}
+	var path string
+	if kubeconfig != nil && *kubeconfig != "" {
+		path = *kubeconfig
+	} else if home := os.Getenv("HOME"); home != "" {
+		path = filepath.Join(home, ".kube", "config")
+	}
+
+	var err error
+
+	restConfig, err = clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
 		log.Fatalf("Failed to load Kubernetes config (E2E tests require a pre-existing cluster; see e2e/README.md): %v", err)
 	}
-	clientset, err = kubernetes.NewForConfig(config)
+	clientset, err = kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		log.Fatalf("Failed to create Kubernetes clientset: %v", err)
 	}
-	dynamicClient, err = dynamic.NewForConfig(config)
+	dynamicClient, err = dynamic.NewForConfig(restConfig)
 	if err != nil {
 		log.Fatalf("Failed to create dynamic client: %v", err)
 	}
@@ -60,28 +105,24 @@ func TestMain(m *testing.M) {
 func TestWebhookMutation_V6eSingleHost(t *testing.T) {
 	rayCluster := loadManifest(t, "../manifests/v6e/v6e-8-single-host.yaml")
 
-	labelSelector := fmt.Sprintf("ray.io/cluster=%s", rayCluster.Name)
-	t.Logf("Looking for pods with selector: %s", labelSelector)
+	labelSelector := getLabelSelector(t, rayCluster.Name)
 
 	pods := waitForPods(t, labelSelector, 2)
 
+	foundWorker := false
 	for _, pod := range pods.Items {
-		if pod.Labels["ray.io/node-type"] == "worker" {
-			envVars := pod.Spec.Containers[0].Env
-			assert.True(t, hasEnvVar(envVars, "TPU_WORKER_ID"), "Missing TPU_WORKER_ID")
-			assert.True(t, hasEnvVar(envVars, "TPU_NAME"), "Missing TPU_NAME")
-			assert.True(t, hasEnvVar(envVars, "TPU_DEVICE_PLUGIN_HOST_IP"), "Missing TPU_DEVICE_PLUGIN_HOST_IP")
-			assert.True(t, hasEnvVar(envVars, "TPU_DEVICE_PLUGIN_ADDR"), "Missing TPU_DEVICE_PLUGIN_ADDR")
-			break
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			foundWorker = true
+			assertCommonTPUEnvVars(t, pod.Spec.Containers[0].Env)
 		}
 	}
+	assert.True(t, foundWorker, "No worker pods found to validate in single host topology")
 }
 
 func TestWebhookMutation_V6eMultiHost(t *testing.T) {
 	rayCluster := loadManifest(t, "../manifests/v6e/v6e-16-multi-host.yaml")
 
-	labelSelector := fmt.Sprintf("ray.io/cluster=%s", rayCluster.Name)
-	t.Logf("Looking for pods with selector: %s", labelSelector)
+	labelSelector := getLabelSelector(t, rayCluster.Name)
 
 	pods := waitForPods(t, labelSelector, 5)
 
@@ -91,21 +132,21 @@ func TestWebhookMutation_V6eMultiHost(t *testing.T) {
 
 	numWorkerPods := 0
 	for _, pod := range pods.Items {
-		if pod.Labels["ray.io/node-type"] == "worker" {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
 			numWorkerPods++
 			envVars := pod.Spec.Containers[0].Env
 
-			workerId := envVarValue(envVars, "TPU_WORKER_ID")
-			tpuName := envVarValue(envVars, "TPU_NAME")
+			workerId := envVarValue(envVars, tpuWorkerIDEnv)
+			tpuName := envVarValue(envVars, tpuNameEnv)
 
-			assert.NotEmpty(t, workerId, "TPU_WORKER_ID is empty")
-			assert.NotEmpty(t, tpuName, "TPU_NAME is empty")
+			assert.NotEmpty(t, workerId, tpuWorkerIDEnv+" is empty")
+			assert.NotEmpty(t, tpuName, tpuNameEnv+" is empty")
 
 			workerIds[workerId] = true
 			tpuNames[tpuName] = true
 
-			replicaIndex := pod.Labels["replicaIndex"]
-			assert.NotEmpty(t, replicaIndex, "replicaIndex label is missing")
+			replicaIndex := pod.Labels[replicaIndexLabelKey]
+			assert.NotEmpty(t, replicaIndex, replicaIndexLabelKey+" label is missing")
 			replicaIndices[replicaIndex] = true
 
 			assert.NotEmpty(t, pod.Spec.Subdomain, "Subdomain not set")
@@ -113,25 +154,44 @@ func TestWebhookMutation_V6eMultiHost(t *testing.T) {
 
 			assert.NotNil(t, pod.Spec.Affinity, "Affinity not set")
 			assert.NotNil(t, pod.Spec.Affinity.PodAntiAffinity, "PodAntiAffinity not set")
+
+			// Assert TPU_DEVICE_PLUGIN_HOST_IP is set via valueFrom fieldRef status.hostIP
+			hostIPVarFound := false
+			for _, env := range envVars {
+				if env.Name == tpuDevicePluginHostIPEnv {
+					hostIPVarFound = true
+					assert.NotNil(t, env.ValueFrom, tpuDevicePluginHostIPEnv+" ValueFrom is nil")
+					assert.NotNil(t, env.ValueFrom.FieldRef, tpuDevicePluginHostIPEnv+" FieldRef is nil")
+					assert.Equal(t, "status.hostIP", env.ValueFrom.FieldRef.FieldPath, tpuDevicePluginHostIPEnv+" FieldPath is incorrect")
+				}
+			}
+			assert.True(t, hostIPVarFound, tpuDevicePluginHostIPEnv+" environment variable missing")
+
+			// Assert TPU_DEVICE_PLUGIN_ADDR is "$(TPU_DEVICE_PLUGIN_HOST_IP):2112"
+			assert.Equal(t, fmt.Sprintf("$(%s):2112", tpuDevicePluginHostIPEnv), envVarValue(envVars, tpuDevicePluginAddrEnv), tpuDevicePluginAddrEnv+" value is incorrect")
+
+			// Assert TPU_WORKER_HOSTNAMES matches the exact list of DNS hostnames
+			numOfHosts := int(rayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts)
+			expectedHostnames := buildExpectedHostnames(numOfHosts, replicaIndex, rayCluster.Name)
+			assert.Equal(t, expectedHostnames, envVarValue(envVars, tpuWorkerHostnamesEnv), tpuWorkerHostnamesEnv+" value is incorrect")
 		}
 	}
 
 	assert.Equal(t, 4, numWorkerPods, "Expected 4 worker pods for v6e multi-host fixture")
-	assert.Equal(t, 4, len(workerIds), "TPU_WORKER_ID values are not unique")
+	assert.Equal(t, 4, len(workerIds), tpuWorkerIDEnv+" values are not unique")
 
 	for i := 0; i < 4; i++ {
-		assert.True(t, workerIds[fmt.Sprint(i)], "Missing TPU_WORKER_ID %d", i)
+		assert.True(t, workerIds[fmt.Sprint(i)], "Missing "+tpuWorkerIDEnv+" %d", i)
 	}
 
-	assert.Equal(t, 1, len(tpuNames), "All pods in the same slice should share the same TPU_NAME")
-	assert.Equal(t, 1, len(replicaIndices), "All pods in the same slice should share the same replicaIndex")
+	assert.Equal(t, 1, len(tpuNames), "All pods in the same slice should share the same "+tpuNameEnv)
+	assert.Equal(t, 1, len(replicaIndices), "All pods in the same slice should share the same "+replicaIndexLabelKey)
 }
 
 func TestWebhookMutation_V6eMultiSlice(t *testing.T) {
 	rayCluster := loadManifest(t, "../manifests/v6e/v6e-16-multi-slice.yaml")
 
-	labelSelector := fmt.Sprintf("ray.io/cluster=%s", rayCluster.Name)
-	t.Logf("Looking for pods with selector: %s", labelSelector)
+	labelSelector := getLabelSelector(t, rayCluster.Name)
 
 	pods := waitForPods(t, labelSelector, 9)
 
@@ -141,21 +201,21 @@ func TestWebhookMutation_V6eMultiSlice(t *testing.T) {
 	megascalePorts := make(map[string]bool)
 
 	for _, pod := range pods.Items {
-		if pod.Labels["ray.io/node-type"] == "worker" {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
 			numWorkerPods++
 			envVars := pod.Spec.Containers[0].Env
 
-			assert.True(t, hasEnvVar(envVars, "MEGASCALE_SLICE_ID"), "Missing MEGASCALE_SLICE_ID")
-			assert.True(t, hasEnvVar(envVars, "MEGASCALE_COORDINATOR_ADDRESS"), "Missing MEGASCALE_COORDINATOR_ADDRESS")
-			assert.True(t, hasEnvVar(envVars, "MEGASCALE_PORT"), "Missing MEGASCALE_PORT")
+			assert.True(t, hasEnvVar(envVars, megascaleSliceIDEnv), "Missing "+megascaleSliceIDEnv)
+			assert.True(t, hasEnvVar(envVars, megascaleCoordinatorAddressEnv), "Missing "+megascaleCoordinatorAddressEnv)
+			assert.True(t, hasEnvVar(envVars, megascalePortEnv), "Missing "+megascalePortEnv)
 
-			sliceId := envVarValue(envVars, "MEGASCALE_SLICE_ID")
+			sliceId := envVarValue(envVars, megascaleSliceIDEnv)
 			sliceIds[sliceId]++
 
-			coordAddr := envVarValue(envVars, "MEGASCALE_COORDINATOR_ADDRESS")
+			coordAddr := envVarValue(envVars, megascaleCoordinatorAddressEnv)
 			coordinatorAddresses[coordAddr] = true
 
-			port := envVarValue(envVars, "MEGASCALE_PORT")
+			port := envVarValue(envVars, megascalePortEnv)
 			megascalePorts[port] = true
 		}
 	}
@@ -174,13 +234,10 @@ func TestWebhookMutation_V6eMultiSlice(t *testing.T) {
 
 func TestWebhookMutation_V6ePodChurnSingleSlice(t *testing.T) {
 	clusterName := "tpu-v6e-multi-host"
-	labelSelector := fmt.Sprintf("ray.io/cluster=%s", clusterName)
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
 
-	// 1. Get initial pods and track their names
-	initialPods, err := clientset.CoreV1().Pods("default").List(t.Context(), metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil || len(initialPods.Items) == 0 {
-		t.Skip("Skipping pod churn test: No multi-host pods found in default namespace.")
-	}
+	// 1. Wait for all expected pods to be created and track their names
+	initialPods := waitForPods(t, labelSelector, 5)
 
 	initialPodNames := make(map[string]bool)
 	for _, p := range initialPods.Items {
@@ -190,7 +247,7 @@ func TestWebhookMutation_V6ePodChurnSingleSlice(t *testing.T) {
 	// 2. Select two worker pods (half the slice) to delete concurrently
 	var targetPods []corev1.Pod
 	for _, pod := range initialPods.Items {
-		if pod.Labels["ray.io/node-type"] == "worker" {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
 			targetPods = append(targetPods, pod)
 			if len(targetPods) == 2 {
 				break
@@ -205,9 +262,9 @@ func TestWebhookMutation_V6ePodChurnSingleSlice(t *testing.T) {
 	// Record their original TPU_WORKER_IDs
 	expectedWorkerIDs := make(map[string]bool)
 	for _, pod := range targetPods {
-		wID := envVarValue(pod.Spec.Containers[0].Env, "TPU_WORKER_ID")
+		wID := envVarValue(pod.Spec.Containers[0].Env, tpuWorkerIDEnv)
 		expectedWorkerIDs[wID] = true
-		t.Logf("Targeting worker pod %s (TPU_WORKER_ID=%s) for deletion", pod.Name, wID)
+		t.Logf("Targeting worker pod %s ("+tpuWorkerIDEnv+"=%s) for deletion", pod.Name, wID)
 	}
 
 	// 3. Delete both worker pods concurrently
@@ -215,51 +272,23 @@ func TestWebhookMutation_V6ePodChurnSingleSlice(t *testing.T) {
 	t.Log("Target pods deleted concurrently. Waiting for KubeRay operator to re-create both...")
 
 	// 4. Poll and wait for the two brand-new worker pods to be created and mutated
-	var recreatedPods []corev1.Pod
-	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
-	defer cancel()
-
-	err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 90*time.Second, true, func(ctx context.Context) (bool, error) {
-		currentPods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
-		if err != nil {
-			return false, err
-		}
-
-		recreatedPods = nil
-		for _, p := range currentPods.Items {
-			if p.Labels["ray.io/node-type"] == "worker" && !initialPodNames[p.Name] {
-				if hasEnvVar(p.Spec.Containers[0].Env, "TPU_WORKER_ID") {
-					recreatedPods = append(recreatedPods, p)
-				}
-			}
-		}
-		if len(recreatedPods) == 2 {
-			return true, nil
-		}
-		t.Logf("Waiting for recreated pods to be mutated... (found %d/2)", len(recreatedPods))
-		return false, nil
-	})
-	if err != nil {
-		t.Fatalf("Timed out waiting for the recreated worker pods: %v (found %d/2)", err, len(recreatedPods))
-	}
+	// 4. Poll and wait for the two brand-new worker pods to be created and mutated
+	recreatedPods := waitForRecreatedPods(t, labelSelector, 2, initialPodNames)
 
 	// 5. Assert that the new pods got the same TPU_WORKER_IDs as before the churn
 	for _, pod := range recreatedPods {
-		assignedID := envVarValue(pod.Spec.Containers[0].Env, "TPU_WORKER_ID")
-		t.Logf("Re-created pod name: %s, Assigned TPU_WORKER_ID: %s", pod.Name, assignedID)
-		assert.True(t, expectedWorkerIDs[assignedID], "Re-created pod TPU_WORKER_ID %s was not in the original expected IDs", assignedID)
+		assignedID := envVarValue(pod.Spec.Containers[0].Env, tpuWorkerIDEnv)
+		t.Logf("Re-created pod name: %s, Assigned "+tpuWorkerIDEnv+": %s", pod.Name, assignedID)
+		assert.True(t, expectedWorkerIDs[assignedID], "Re-created pod "+tpuWorkerIDEnv+" %s was not in the original expected IDs", assignedID)
 	}
 }
 
 func TestWebhookMutation_V6ePodChurnMultiSlice(t *testing.T) {
 	clusterName := "tpu-v6e-multi-slice"
-	labelSelector := fmt.Sprintf("ray.io/cluster=%s", clusterName)
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
 
-	// 1. Get initial pods and track their names
-	initialPods, err := clientset.CoreV1().Pods("default").List(t.Context(), metav1.ListOptions{LabelSelector: labelSelector})
-	if err != nil || len(initialPods.Items) == 0 {
-		t.Skip("Skipping pod churn test: No multi-slice pods found in default namespace.")
-	}
+	// 1. Wait for all expected pods to be created and track their names
+	initialPods := waitForPods(t, labelSelector, 9)
 
 	initialPodNames := make(map[string]bool)
 	for _, p := range initialPods.Items {
@@ -271,8 +300,8 @@ func TestWebhookMutation_V6ePodChurnMultiSlice(t *testing.T) {
 	var slice0Targets, slice1Targets []corev1.Pod
 
 	for _, pod := range initialPods.Items {
-		if pod.Labels["ray.io/node-type"] == "worker" {
-			sliceID := envVarValue(pod.Spec.Containers[0].Env, "MEGASCALE_SLICE_ID")
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			sliceID := envVarValue(pod.Spec.Containers[0].Env, megascaleSliceIDEnv)
 			if sliceID == "0" && len(slice0Targets) < 2 {
 				slice0Targets = append(slice0Targets, pod)
 			} else if sliceID == "1" && len(slice1Targets) < 2 {
@@ -294,54 +323,49 @@ func TestWebhookMutation_V6ePodChurnMultiSlice(t *testing.T) {
 	expectedPodMappings["1"] = make(map[string]bool)
 
 	for _, pod := range targetPods {
-		sliceID := envVarValue(pod.Spec.Containers[0].Env, "MEGASCALE_SLICE_ID")
-		wID := envVarValue(pod.Spec.Containers[0].Env, "TPU_WORKER_ID")
+		sliceID := envVarValue(pod.Spec.Containers[0].Env, megascaleSliceIDEnv)
+		wID := envVarValue(pod.Spec.Containers[0].Env, tpuWorkerIDEnv)
 		expectedPodMappings[sliceID][wID] = true
-		t.Logf("Targeting multi-slice worker pod %s (Slice=%s, TPU_WORKER_ID=%s) for deletion", pod.Name, sliceID, wID)
+		t.Logf("Targeting multi-slice worker pod %s (Slice=%s, "+tpuWorkerIDEnv+"=%s) for deletion", pod.Name, sliceID, wID)
 	}
 
 	// 3. Delete all four worker pods concurrently
 	deletePodsConcurrently(t, targetPods)
-	t.Log("Target pods deleted concurrently. Waiting for KubeRay operator to re-create all four...")
+	t.Log("Target pods deleted concurrently. Polling and triggering KubeRay operator reconciliation until recreation starts...")
 
-	// 4. Poll and wait for all four new worker pods to be created and mutated
-	var recreatedPods []corev1.Pod
-	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
-	defer cancel()
-
-	err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 90*time.Second, true, func(ctx context.Context) (bool, error) {
-		currentPods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	// Wait for KubeRay Operator to satisfy its informer expectations and start recreation
+	err := wait.PollUntilContextTimeout(t.Context(), 4*time.Second, 45*time.Second, true, func(ctx context.Context) (bool, error) {
+		triggerRayClusterReconcile(t, clusterName)
+		currentPods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			return false, err
 		}
-
-		recreatedPods = nil
 		for _, p := range currentPods.Items {
-			if p.Labels["ray.io/node-type"] == "worker" && !initialPodNames[p.Name] {
-				if hasEnvVar(p.Spec.Containers[0].Env, "TPU_WORKER_ID") && hasEnvVar(p.Spec.Containers[0].Env, "MEGASCALE_SLICE_ID") {
-					recreatedPods = append(recreatedPods, p)
-				}
+			if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker && !initialPodNames[p.Name] {
+				t.Log("Recreation has successfully started!")
+				return true, nil
 			}
 		}
-		if len(recreatedPods) == 4 {
-			return true, nil
-		}
-		t.Logf("Waiting for recreated multi-slice pods... (found %d/4)", len(recreatedPods))
 		return false, nil
 	})
 	if err != nil {
-		t.Fatalf("Timed out waiting for the recreated worker pods in multi-slice cluster: %v (found %d/4)", err, len(recreatedPods))
+		t.Fatalf("Timed out waiting for KubeRay operator to start recreating pods: %v", err)
 	}
+
+	t.Log("Recreation started. Waiting for KubeRay operator to fully re-create and mutate all four Pods...")
+
+	// 4. Poll and wait for all four new worker pods to be created and mutated
+	recreatedPods := waitForRecreatedPods(t, labelSelector, 4, initialPodNames)
 
 	// 5. Assert that each recreated pod got its original TPU_WORKER_ID under the correct MEGASCALE_SLICE_ID
 	for _, pod := range recreatedPods {
-		sliceID := envVarValue(pod.Spec.Containers[0].Env, "MEGASCALE_SLICE_ID")
-		assignedID := envVarValue(pod.Spec.Containers[0].Env, "TPU_WORKER_ID")
-		t.Logf("Re-created multi-slice pod name: %s, Assigned Slice: %s, TPU_WORKER_ID: %s", pod.Name, sliceID, assignedID)
+		sliceID := envVarValue(pod.Spec.Containers[0].Env, megascaleSliceIDEnv)
+		assignedID := envVarValue(pod.Spec.Containers[0].Env, tpuWorkerIDEnv)
+		t.Logf("Re-created multi-slice pod name: %s, Assigned Slice: %s, "+tpuWorkerIDEnv+": %s", pod.Name, sliceID, assignedID)
 
 		originalExpectedIDs, exists := expectedPodMappings[sliceID]
 		assert.True(t, exists, "Recreated pod assigned to unexpected sliceID: %s", sliceID)
-		assert.True(t, originalExpectedIDs[assignedID], "Recreated pod in slice %s with TPU_WORKER_ID %s was not in the original expected set", sliceID, assignedID)
+		assert.True(t, originalExpectedIDs[assignedID], "Recreated pod in slice %s with "+tpuWorkerIDEnv+" %s was not in the original expected set", sliceID, assignedID)
 	}
 }
 
@@ -369,12 +393,9 @@ func loadManifest(t *testing.T, relativePath string) *rayv1.RayCluster {
 func waitForPods(t *testing.T, labelSelector string, expectedCount int) *corev1.PodList {
 	t.Helper()
 	var pods *corev1.PodList
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
-
-	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(t.Context(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		var err error
-		pods, err = clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		pods, err = clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 		if err != nil {
 			return false, err
 		}
@@ -387,6 +408,107 @@ func waitForPods(t *testing.T, labelSelector string, expectedCount int) *corev1.
 		t.Fatalf("Error waiting for %d pods with selector %s: %v (found %d pods)", expectedCount, labelSelector, err, len(pods.Items))
 	}
 	return pods
+}
+
+func TestWebhookMutation_HeterogeneousCluster(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v6e/heterogeneous-cluster.yaml")
+
+	labelSelector := getLabelSelector(t, rayCluster.Name)
+
+	pods := waitForPods(t, labelSelector, 3)
+
+	numTpuWorkers := 0
+	numCpuWorkers := 0
+
+	for _, pod := range pods.Items {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			if pod.Labels[utils.RayNodeGroupLabelKey] == "tpu-worker-group" {
+				numTpuWorkers++
+				envVars := pod.Spec.Containers[0].Env
+				assert.True(t, hasEnvVar(envVars, tpuWorkerIDEnv), "TPU worker missing "+tpuWorkerIDEnv)
+				assert.NotEmpty(t, pod.Labels[replicaIndexLabelKey], "TPU worker missing "+replicaIndexLabelKey+" label")
+			} else if pod.Labels[utils.RayNodeGroupLabelKey] == "cpu-worker-group" {
+				numCpuWorkers++
+				envVars := pod.Spec.Containers[0].Env
+				assert.False(t, hasEnvVar(envVars, tpuWorkerIDEnv), "CPU worker erroneously mutated with "+tpuWorkerIDEnv)
+				assert.Empty(t, pod.Labels[replicaIndexLabelKey], "CPU worker erroneously mutated with "+replicaIndexLabelKey+" label")
+				assert.Empty(t, pod.Spec.Subdomain, "CPU worker subdomain should be empty")
+				assert.Empty(t, pod.Spec.Hostname, "CPU worker hostname should be empty")
+				assert.Nil(t, pod.Spec.Affinity, "CPU worker affinity should be nil")
+			}
+		}
+	}
+
+	assert.Equal(t, 1, numTpuWorkers, "Expected exactly 1 TPU worker pod")
+	assert.Equal(t, 1, numCpuWorkers, "Expected exactly 1 CPU worker pod")
+}
+
+func TestWebhookMutation_V7xSingleHost(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v7x/v7x-8-single-host.yaml")
+
+	labelSelector := getLabelSelector(t, rayCluster.Name)
+
+	pods := waitForPods(t, labelSelector, 2)
+
+	foundWorker := false
+	for _, pod := range pods.Items {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			foundWorker = true
+			envVars := pod.Spec.Containers[0].Env
+			assertCommonTPUEnvVars(t, envVars)
+			assert.Equal(t, "0", envVarValue(envVars, tpuWorkerIDEnv), tpuWorkerIDEnv+" is incorrect")
+		}
+	}
+	assert.True(t, foundWorker, "No worker pods found to validate in V7x single host topology")
+}
+
+func TestWebhookMutation_V7xMultiHost(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v7x/v7x-16-multi-host.yaml")
+
+	labelSelector := getLabelSelector(t, rayCluster.Name)
+
+	pods := waitForPods(t, labelSelector, 3)
+
+	workerIds := make(map[string]bool)
+	tpuNames := make(map[string]bool)
+
+	numWorkerPods := 0
+	for _, pod := range pods.Items {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			numWorkerPods++
+			envVars := pod.Spec.Containers[0].Env
+
+			workerId := envVarValue(envVars, tpuWorkerIDEnv)
+			tpuName := envVarValue(envVars, tpuNameEnv)
+
+			assert.NotEmpty(t, workerId, tpuWorkerIDEnv+" is empty")
+			assert.NotEmpty(t, tpuName, tpuNameEnv+" is empty")
+
+			workerIds[workerId] = true
+			tpuNames[tpuName] = true
+
+			assert.NotEmpty(t, pod.Spec.Subdomain, "Subdomain not set")
+			assert.NotEmpty(t, pod.Spec.Hostname, "Hostname not set")
+
+			replicaIndex := pod.Labels[replicaIndexLabelKey]
+			assert.NotEmpty(t, replicaIndex, replicaIndexLabelKey+" label is missing")
+
+			// Assert v7x-specific process address variables dynamically
+			numOfHosts := int(rayCluster.Spec.WorkerGroupSpecs[0].NumOfHosts)
+			// Determine number of TPU containers per pod from manifest resource requests (google.com/tpu: "4")
+			// We'll assume 1 TPU container per pod since requests: 4 for tpu7x (which is a dual-chiplet host with 4 chips total).
+			numTpuContainers := 1
+			expectedAddresses := buildExpectedProcessAddresses(numOfHosts, replicaIndex, rayCluster.Name, numTpuContainers)
+			assert.Equal(t, expectedAddresses, envVarValue(envVars, tpuProcessAddressesEnv), tpuProcessAddressesEnv+" value is incorrect")
+			assert.Equal(t, "8471", envVarValue(envVars, tpuProcessPortEnv), tpuProcessPortEnv+" value is incorrect")
+		}
+	}
+
+	assert.Equal(t, 2, numWorkerPods, "Expected 2 worker pods for v7x multi-host fixture")
+	assert.Equal(t, 2, len(workerIds), tpuWorkerIDEnv+" values are not unique")
+	assert.True(t, workerIds["0"], "Missing "+tpuWorkerIDEnv+" 0")
+	assert.True(t, workerIds["1"], "Missing "+tpuWorkerIDEnv+" 1")
+	assert.Equal(t, 1, len(tpuNames), "All pods in the same slice should share the same "+tpuNameEnv)
 }
 
 func hasEnvVar(envVars []corev1.EnvVar, name string) bool {
@@ -414,9 +536,25 @@ func deletePodsConcurrently(t *testing.T, pods []corev1.Pod) {
 		wg.Add(1)
 		go func(podName string) {
 			defer wg.Done()
-			err := clientset.CoreV1().Pods("default").Delete(t.Context(), podName, metav1.DeleteOptions{})
-			if err != nil {
+			err := clientset.CoreV1().Pods(testNamespace).Delete(t.Context(), podName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
 				t.Errorf("Failed to delete pod %s: %v", podName, err)
+				return
+			}
+
+			// Wait for the pod to be completely removed from the API server (graceful cleanup finished)
+			err = wait.PollUntilContextTimeout(t.Context(), 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+				_, err := clientset.CoreV1().Pods(testNamespace).Get(ctx, podName, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			})
+			if err != nil {
+				t.Errorf("Pod %s was not fully deleted within 60s: %v", podName, err)
 			}
 		}(pod.Name)
 	}
@@ -424,4 +562,279 @@ func deletePodsConcurrently(t *testing.T, pods []corev1.Pod) {
 	if t.Failed() {
 		t.FailNow()
 	}
+}
+
+func buildExpectedHostnames(numOfHosts int, replicaIndexLabelVal string, clusterName string) string {
+	headlessService := fmt.Sprintf("%s-headless", clusterName)
+	hostnames := make([]string, numOfHosts)
+	for j := 0; j < numOfHosts; j++ {
+		hostnames[j] = fmt.Sprintf("%s-%d.%s", replicaIndexLabelVal, j, headlessService)
+	}
+	return strings.Join(hostnames, ",")
+}
+
+func buildExpectedProcessAddresses(numOfHosts int, replicaIndexLabelVal string, clusterName string, numTpuContainers int) string {
+	headlessService := fmt.Sprintf("%s-headless", clusterName)
+	var addresses []string
+	for h := 0; h < numOfHosts; h++ {
+		hostName := fmt.Sprintf("%s-%d.%s", replicaIndexLabelVal, h, headlessService)
+		for c := 0; c < numTpuContainers; c++ {
+			port := 8471 + c
+			addresses = append(addresses, fmt.Sprintf("%s:%d", hostName, port))
+		}
+	}
+	return strings.Join(addresses, ",")
+}
+
+func TestWebhookMutation_V7xMultiContainer(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v7x/v7x-multi-container.yaml")
+
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, rayCluster.Name)
+	t.Logf("Looking for pods with selector: %s", labelSelector)
+
+	pods := waitForPods(t, labelSelector, 2)
+
+	foundWorker := false
+	for _, pod := range pods.Items {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			foundWorker = true
+			assert.Equal(t, 2, len(pod.Spec.Containers), "Expected Pod to have exactly 2 containers")
+
+			// Container 0 gets TPU_WORKER_ID 0 and base process port 8471
+			envVars0 := pod.Spec.Containers[0].Env
+			assert.Equal(t, "0", envVarValue(envVars0, tpuWorkerIDEnv), "Container 0 "+tpuWorkerIDEnv+" is incorrect")
+			assert.Equal(t, "8471", envVarValue(envVars0, tpuProcessPortEnv), "Container 0 "+tpuProcessPortEnv+" is incorrect")
+
+			// Container 1 gets TPU_WORKER_ID 1 and consecutive process port 8472
+			envVars1 := pod.Spec.Containers[1].Env
+			assert.Equal(t, "1", envVarValue(envVars1, tpuWorkerIDEnv), "Container 1 "+tpuWorkerIDEnv+" is incorrect")
+			assert.Equal(t, "8472", envVarValue(envVars1, tpuProcessPortEnv), "Container 1 "+tpuProcessPortEnv+" is incorrect")
+		}
+	}
+	assert.True(t, foundWorker, "No worker pods found to validate in V7x multi-container topology")
+}
+
+func TestWebhookMutation_V7xMultiSlice(t *testing.T) {
+	rayCluster := loadManifest(t, "../manifests/v7x/v7x-16-multi-slice.yaml")
+
+	labelSelector := getLabelSelector(t, rayCluster.Name)
+
+	pods := waitForPods(t, labelSelector, 5)
+
+	numWorkerPods := 0
+	sliceIds := make(map[string]int)
+	coordinatorAddresses := make(map[string]bool)
+
+	for _, pod := range pods.Items {
+		if pod.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			numWorkerPods++
+			envVars := pod.Spec.Containers[0].Env
+
+			assert.True(t, hasEnvVar(envVars, megascaleSliceIDEnv), "Missing "+megascaleSliceIDEnv)
+			assert.True(t, hasEnvVar(envVars, megascaleCoordinatorAddressEnv), "Missing "+megascaleCoordinatorAddressEnv)
+			assert.True(t, hasEnvVar(envVars, megascalePortEnv), "Missing "+megascalePortEnv)
+
+			sliceId := envVarValue(envVars, megascaleSliceIDEnv)
+			sliceIds[sliceId]++
+
+			coordAddr := envVarValue(envVars, megascaleCoordinatorAddressEnv)
+			coordinatorAddresses[coordAddr] = true
+		}
+	}
+
+	assert.Equal(t, 4, numWorkerPods, "Expected 4 worker pods (2 slices of 2 hosts)")
+	assert.Equal(t, 2, len(sliceIds), "Expected 2 distinct slice IDs")
+	assert.Equal(t, 2, sliceIds["0"], "Expected 2 worker pods in slice 0")
+	assert.Equal(t, 2, sliceIds["1"], "Expected 2 worker pods in slice 1")
+
+	assert.Equal(t, 1, len(coordinatorAddresses), "All containers in a multi-slice group should share the same coordinator address")
+	assert.True(t, coordinatorAddresses["tpu-worker-group-0-0.tpu-v7x-multi-slice-headless:8081"], "Unexpected coordinator address")
+}
+
+func TestWebhookMutation_V6eDNSResolution(t *testing.T) {
+	clusterName := "tpu-v6e-multi-host"
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
+
+	pods, err := clientset.CoreV1().Pods(testNamespace).List(t.Context(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil || len(pods.Items) == 0 {
+		t.Skip("Skipping DNS resolution test: No multi-host pods found in default namespace.")
+	}
+
+	var workerPod *corev1.Pod
+	for _, p := range pods.Items {
+		if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+			workerPod = &p
+			break
+		}
+	}
+
+	if workerPod == nil {
+		t.Fatalf("No TPU worker pods found in cluster %s", clusterName)
+	}
+
+	// Wait for all worker pods to be in Running phase so DNS endpoints are fully registered
+	t.Log("Waiting for all worker pods to reach Running phase...")
+	err = wait.PollUntilContextTimeout(t.Context(), 3*time.Second, 120*time.Second, true, func(ctx context.Context) (bool, error) {
+		currentPods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+
+		allRunning := true
+		workerCount := 0
+		for _, p := range currentPods.Items {
+			if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker {
+				workerCount++
+				if p.Status.Phase != corev1.PodRunning {
+					allRunning = false
+					break
+				}
+				// Ensure container status is also running
+				containerRunning := false
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name == p.Spec.Containers[0].Name && cs.State.Running != nil {
+						containerRunning = true
+						break
+					}
+				}
+				if !containerRunning {
+					allRunning = false
+					break
+				}
+			}
+		}
+		return allRunning && workerCount > 0, nil
+	})
+	if err != nil {
+		t.Fatalf("Not all worker pods reached Running phase within 120s: %v", err)
+	}
+
+	// Wait for CoreDNS/Kube-DNS propagation to fully sync endpoints
+	t.Log("All worker pods are Running. Waiting 5 seconds for DNS propagation...")
+	time.Sleep(5 * time.Second)
+
+	// Refresh target workerPod reference to ensure status reflects Running state
+	p, err := clientset.CoreV1().Pods(testNamespace).Get(t.Context(), workerPod.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to refresh worker pod status: %v", err)
+	}
+	workerPod = p
+
+	envVars := workerPod.Spec.Containers[0].Env
+	hostnamesStr := envVarValue(envVars, tpuWorkerHostnamesEnv)
+	assert.NotEmpty(t, hostnamesStr, tpuWorkerHostnamesEnv+" env var is missing or empty")
+
+	hostnames := strings.Split(hostnamesStr, ",")
+	for _, hostname := range hostnames {
+		t.Logf("Attempting to resolve hostname %s from inside pod %s...", hostname, workerPod.Name)
+		stdout, stderr, err := execCommandInPod(t, workerPod.Name, workerPod.Spec.Containers[0].Name, []string{"getent", "hosts", hostname})
+		if err != nil {
+			t.Errorf("Failed to resolve hostname %s inside container: %v (stderr: %q, stdout: %q)", hostname, err, stderr, stdout)
+		} else {
+			t.Logf("Successfully resolved %s: %s", hostname, strings.TrimSpace(stdout))
+		}
+	}
+}
+
+func execCommandInPod(t *testing.T, podName string, containerName string, cmd []string) (string, string, error) {
+	t.Helper()
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(testNamespace).
+		SubResource("exec")
+	option := &corev1.PodExecOptions{
+		Container: containerName,
+		Command:   cmd,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}
+	req.VersionedParams(option, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(t.Context(), remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	return stdout.String(), stderr.String(), err
+}
+
+func triggerRayClusterReconcile(t *testing.T, clusterName string) {
+	t.Helper()
+	gvr := schema.GroupVersionResource{
+		Group:    "ray.io",
+		Version:  "v1",
+		Resource: "rayclusters",
+	}
+	cluster, err := dynamicClient.Resource(gvr).Namespace(testNamespace).Get(t.Context(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get RayCluster %s: %v", clusterName, err)
+	}
+
+	annotations := cluster.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["tpu-webhook.gke.io/reconcile-trigger"] = fmt.Sprint(time.Now().UnixNano())
+	cluster.SetAnnotations(annotations)
+
+	_, err = dynamicClient.Resource(gvr).Namespace(testNamespace).Update(t.Context(), cluster, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to trigger reconciliation for RayCluster %s: %v", clusterName, err)
+	}
+	t.Logf("Successfully triggered immediate KubeRay reconciliation for %s", clusterName)
+}
+
+func getLabelSelector(t *testing.T, clusterName string) string {
+	t.Helper()
+	labelSelector := fmt.Sprintf("%s=%s", utils.RayClusterLabelKey, clusterName)
+	t.Logf("Looking for pods with selector: %s", labelSelector)
+	return labelSelector
+}
+
+func assertCommonTPUEnvVars(t *testing.T, envVars []corev1.EnvVar) {
+	t.Helper()
+	assert.True(t, hasEnvVar(envVars, tpuWorkerIDEnv), "Missing "+tpuWorkerIDEnv)
+	assert.NotEmpty(t, envVarValue(envVars, tpuWorkerIDEnv), tpuWorkerIDEnv+" is empty")
+
+	assert.True(t, hasEnvVar(envVars, tpuNameEnv), "Missing "+tpuNameEnv)
+	assert.NotEmpty(t, envVarValue(envVars, tpuNameEnv), tpuNameEnv+" is empty")
+
+	assert.True(t, hasEnvVar(envVars, tpuDevicePluginHostIPEnv), "Missing "+tpuDevicePluginHostIPEnv)
+	assert.True(t, hasEnvVar(envVars, tpuDevicePluginAddrEnv), "Missing "+tpuDevicePluginAddrEnv)
+}
+
+func waitForRecreatedPods(t *testing.T, labelSelector string, expectedCount int, initialPodNames map[string]bool) []corev1.Pod {
+	t.Helper()
+	var recreatedPods []corev1.Pod
+	err := wait.PollUntilContextTimeout(t.Context(), 3*time.Second, 90*time.Second, true, func(ctx context.Context) (bool, error) {
+		currentPods, err := clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, err
+		}
+
+		recreatedPods = nil
+		for _, p := range currentPods.Items {
+			if p.Labels[utils.RayNodeTypeLabelKey] == rayNodeTypeWorker && !initialPodNames[p.Name] {
+				if hasEnvVar(p.Spec.Containers[0].Env, tpuWorkerIDEnv) {
+					recreatedPods = append(recreatedPods, p)
+				}
+			}
+		}
+		if len(recreatedPods) == expectedCount {
+			return true, nil
+		}
+		t.Logf("Waiting for recreated pods... (found %d/%d)", len(recreatedPods), expectedCount)
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for recreated pods: %v (found %d/%d)", err, len(recreatedPods), expectedCount)
+	}
+	return recreatedPods
 }

--- a/e2e/webhook/tpu_raycluster_validation_test.go
+++ b/e2e/webhook/tpu_raycluster_validation_test.go
@@ -15,12 +15,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	errTopologyMismatch = "Number of workers in worker group not equal to specified topology"
+)
+
 func TestRayClusterValidation_InvalidTopology(t *testing.T) {
 	baseCluster := loadManifest(t, "../manifests/invalid/invalid-topology.yaml")
 
 	t.Log("Running validating webhook case: Strict Topology Mismatch Rejection")
 	// Base invalid-topology manifest has replica workerGroup with numOfHosts: 2 but requests 2x4 topology (expected 1 host)
-	assertRayClusterRejected(t, baseCluster, "Number of workers in worker group not equal to specified topology")
+	assertRayClusterRejected(t, baseCluster, errTopologyMismatch)
 }
 
 func TestRayClusterValidation_MissingTopologyKey(t *testing.T) {
@@ -37,6 +41,19 @@ func TestRayClusterValidation_MissingTopologyKey(t *testing.T) {
 	assertRayClusterRejected(t, cluster, "Failed to validate RayCluster")
 }
 
+func TestRayClusterValidation_NumOfHostsZero(t *testing.T) {
+	cluster := loadManifest(t, "../manifests/invalid/invalid-num-of-hosts-zero.yaml")
+	t.Log("Running validating webhook case: NumOfHosts=0 Rejection")
+	assertRayClusterRejected(t, cluster, errTopologyMismatch)
+}
+
+func TestRayClusterValidation_NumOfHostsOmitted(t *testing.T) {
+	cluster := loadManifest(t, "../manifests/invalid/invalid-num-of-hosts-omitted.yaml")
+	t.Log("Running validating webhook case: NumOfHosts omitted Rejection")
+	assertRayClusterRejected(t, cluster, errTopologyMismatch)
+}
+
+
 func assertRayClusterRejected(t *testing.T, cluster *rayv1.RayCluster, expectedErrorMessage string) {
 	t.Helper()
 	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cluster)
@@ -50,14 +67,16 @@ func assertRayClusterRejected(t *testing.T, cluster *rayv1.RayCluster, expectedE
 		Resource: "rayclusters",
 	}
 
-	_, err = dynamicClient.Resource(gvr).Namespace("default").Create(
+	res, err := dynamicClient.Resource(gvr).Namespace(testNamespace).Create(
 		t.Context(),
 		&unstructured.Unstructured{Object: unstructuredObj},
 		metav1.CreateOptions{},
 	)
-
-	// Assert that creation was rejected by the validating webhook
-	assert.Error(t, err, "Expected cluster creation to fail due to webhook validation")
+	if err == nil {
+		t.Logf("Cleaning up leaked RayCluster %q...", res.GetName())
+		_ = dynamicClient.Resource(gvr).Namespace(testNamespace).Delete(t.Context(), res.GetName(), metav1.DeleteOptions{})
+		t.Fatalf("Expected cluster creation to fail due to webhook validation, but it succeeded")
+	}
 
 	statusErr, ok := err.(*apierrors.StatusError)
 	if !ok {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/GoogleCloudPlatform/kuberay-tpu-webhook
 go 1.25.9
 
 require (
+	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/ray-project/kuberay/ray-operator v1.5.0
 	github.com/stretchr/testify v1.11.0
 	k8s.io/api v0.34.1
@@ -20,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -32,12 +32,15 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -45,6 +47,8 @@ github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
 github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -63,6 +67,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -71,6 +77,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -8,6 +8,7 @@ PROJECT_ID=${PROJECT_ID:-$(gcloud config get project)}
 CLUSTER_NAME=${CLUSTER_NAME:-ray-llm-cluster}
 ZONE=${ZONE:-us-central2-b}
 NAMESPACE=${NAMESPACE:-default}
+RAY_IMAGE=${RAY_IMAGE:-rayproject/ray:nightly-tpu}
 if [ "$NAMESPACE" = "default" ]; then
     NAMESPACE="test-ns-$(head /dev/urandom | tr -dc a-z0-9 | head -c 5)"
 fi
@@ -79,10 +80,10 @@ TEST_EXIT_CODE=0
 
 # 1. Run Single-Host, Validation, Heterogeneous, and V7x Single-Host/Multi-Container tests
 echo "Deploying Single-Host, Heterogeneous, and V7x test manifests inside namespace $NAMESPACE..."
-kubectl apply -f e2e/manifests/v6e/v6e-8-single-host.yaml -n "$NAMESPACE"
-kubectl apply -f e2e/manifests/v6e/heterogeneous-cluster.yaml -n "$NAMESPACE"
-kubectl apply -f e2e/manifests/v7x/v7x-8-single-host.yaml -n "$NAMESPACE"
-kubectl apply -f e2e/manifests/v7x/v7x-multi-container.yaml -n "$NAMESPACE"
+cat e2e/manifests/v6e/v6e-8-single-host.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+cat e2e/manifests/v6e/heterogeneous-cluster.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+cat e2e/manifests/v7x/v7x-8-single-host.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+cat e2e/manifests/v7x/v7x-multi-container.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Validation, Single-Host, & Multi-Container E2E tests (Group 1)..."
 go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation|TestWebhookMutation_HeterogeneousCluster|TestWebhookMutation_V7xSingleHost|TestWebhookMutation_V7xMultiContainer"
@@ -103,8 +104,8 @@ sleep 10
 
 # 2. Run Multi-Host, Single-Slice Churn, DNS, and V7x Multi-Host tests
 echo "Deploying Multi-Host and V7x Multi-Host manifests inside namespace $NAMESPACE..."
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-host.yaml -n "$NAMESPACE"
-kubectl apply -f e2e/manifests/v7x/v7x-16-multi-host.yaml -n "$NAMESPACE"
+cat e2e/manifests/v6e/v6e-16-multi-host.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+cat e2e/manifests/v7x/v7x-16-multi-host.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Multi-Host, DNS, & Pod Churn E2E tests (Group 2)..."
 go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice|TestWebhookMutation_V6eDNSResolution|TestWebhookMutation_V7xMultiHost"
@@ -123,8 +124,8 @@ sleep 10
 
 # 3. Run Megascale Multi-Slice, Multi-Slice Churn, and V7x Multi-Slice tests
 echo "Deploying Megascale Multi-Slice and V7x Multi-Slice manifests inside namespace $NAMESPACE..."
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-slice.yaml -n "$NAMESPACE"
-kubectl apply -f e2e/manifests/v7x/v7x-16-multi-slice.yaml -n "$NAMESPACE"
+cat e2e/manifests/v6e/v6e-16-multi-slice.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
+cat e2e/manifests/v7x/v7x-16-multi-slice.yaml | sed "s|rayproject/ray:nightly-tpu|$RAY_IMAGE|g" | kubectl apply -n "$NAMESPACE" -f -
 set +e
 echo "Running Multi-Slice (Megascale) & Multi-Slice Churn E2E tests (Group 3)..."
 go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice|TestWebhookMutation_V7xMultiSlice"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -8,6 +8,10 @@ PROJECT_ID=${PROJECT_ID:-$(gcloud config get project)}
 CLUSTER_NAME=${CLUSTER_NAME:-ray-llm-cluster}
 ZONE=${ZONE:-us-central2-b}
 NAMESPACE=${NAMESPACE:-default}
+if [ "$NAMESPACE" = "default" ]; then
+    NAMESPACE="test-ns-$(head /dev/urandom | tr -dc a-z0-9 | head -c 5)"
+fi
+export TEST_NAMESPACE="$NAMESPACE"
 REGION=${REGION:-us-central2}
 NETWORK_NAME=${NETWORK_NAME:-${CLUSTER_NAME}-net}
 SUBNET_NAME=${SUBNET_NAME:-${NETWORK_NAME}-subnet}
@@ -58,50 +62,84 @@ kubectl apply -f certs/
 echo "Waiting for webhook to be ready..."
 kubectl wait --for=condition=Available deployment/kuberay-tpu-webhook -n ray-system --timeout=300s
 
+# Wait for any terminating test namespaces from previous runs to fully clean up (prevents GKE TPU hardware resource locks)
+echo "Checking for any terminating namespaces in the cluster..."
+while kubectl get ns -o json | grep -q '"phase": "Terminating"'; do
+    echo "Waiting for terminating namespaces to fully release GKE TPU hardware..."
+    sleep 5
+done
+echo "Cluster is clean of terminating namespaces."
+
+# Create isolated test namespace
+echo "Creating isolated test namespace $NAMESPACE..."
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
 # Initialize final exit code
 TEST_EXIT_CODE=0
 
-# 1. Run Single-Host and Validation test sequence
-echo "Deploying Single-Host test manifest..."
-kubectl apply -f e2e/manifests/v6e/v6e-8-single-host.yaml
+# 1. Run Single-Host, Validation, Heterogeneous, and V7x Single-Host/Multi-Container tests
+echo "Deploying Single-Host, Heterogeneous, and V7x test manifests inside namespace $NAMESPACE..."
+kubectl apply -f e2e/manifests/v6e/v6e-8-single-host.yaml -n "$NAMESPACE"
+kubectl apply -f e2e/manifests/v6e/heterogeneous-cluster.yaml -n "$NAMESPACE"
+kubectl apply -f e2e/manifests/v7x/v7x-8-single-host.yaml -n "$NAMESPACE"
+kubectl apply -f e2e/manifests/v7x/v7x-multi-container.yaml -n "$NAMESPACE"
 set +e
-echo "Running Single-Host and Validation tests..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation"
-SINGLE_HOST_EXIT=$?
+echo "Running Validation, Single-Host, & Multi-Container E2E tests (Group 1)..."
+go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eSingleHost|TestRayClusterValidation|TestWebhookMutation_HeterogeneousCluster|TestWebhookMutation_V7xSingleHost|TestWebhookMutation_V7xMultiContainer"
+GROUP1_EXIT=$?
 set -e
-echo "Cleaning up Single-Host test manifest..."
-kubectl delete -f e2e/manifests/v6e/v6e-8-single-host.yaml --ignore-not-found=true || true
-if [ $SINGLE_HOST_EXIT -ne 0 ]; then
-    TEST_EXIT_CODE=$SINGLE_HOST_EXIT
+echo "Cleaning up Validation, Single-Host, & Multi-Container manifests..."
+kubectl delete -f e2e/manifests/v6e/v6e-8-single-host.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+kubectl delete -f e2e/manifests/v6e/heterogeneous-cluster.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+kubectl delete -f e2e/manifests/v7x/v7x-8-single-host.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+kubectl delete -f e2e/manifests/v7x/v7x-multi-container.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+if [ $GROUP1_EXIT -ne 0 ]; then
+    TEST_EXIT_CODE=$GROUP1_EXIT
 fi
 
-# 2. Run Multi-Host and Single-Slice Churn test sequence
-echo "Deploying Multi-Host test manifest..."
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-host.yaml
+# Wait to allow TPU device plugin hardware state synchronization
+echo "Waiting 10 seconds for TPU hardware resource detransitions..."
+sleep 10
+
+# 2. Run Multi-Host, Single-Slice Churn, DNS, and V7x Multi-Host tests
+echo "Deploying Multi-Host and V7x Multi-Host manifests inside namespace $NAMESPACE..."
+kubectl apply -f e2e/manifests/v6e/v6e-16-multi-host.yaml -n "$NAMESPACE"
+kubectl apply -f e2e/manifests/v7x/v7x-16-multi-host.yaml -n "$NAMESPACE"
 set +e
-echo "Running Multi-Host and Single-Slice Churn tests..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice"
-MULTI_HOST_EXIT=$?
+echo "Running Multi-Host, DNS, & Pod Churn E2E tests (Group 2)..."
+go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiHost|TestWebhookMutation_V6ePodChurnSingleSlice|TestWebhookMutation_V6eDNSResolution|TestWebhookMutation_V7xMultiHost"
+GROUP2_EXIT=$?
 set -e
-echo "Cleaning up Multi-Host test manifest..."
-kubectl delete -f e2e/manifests/v6e/v6e-16-multi-host.yaml --ignore-not-found=true || true
-if [ $MULTI_HOST_EXIT -ne 0 ]; then
-    TEST_EXIT_CODE=$MULTI_HOST_EXIT
+echo "Cleaning up Multi-Host manifests..."
+kubectl delete -f e2e/manifests/v6e/v6e-16-multi-host.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+kubectl delete -f e2e/manifests/v7x/v7x-16-multi-host.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+if [ $GROUP2_EXIT -ne 0 ]; then
+    TEST_EXIT_CODE=$GROUP2_EXIT
 fi
 
-# 3. Run Megascale Multi-Slice and Multi-Slice Churn test sequence
-echo "Deploying Megascale Multi-Slice test manifest..."
-kubectl apply -f e2e/manifests/v6e/v6e-16-multi-slice.yaml
+# Wait to allow TPU device plugin hardware state synchronization
+echo "Waiting 10 seconds for TPU hardware resource detransitions..."
+sleep 10
+
+# 3. Run Megascale Multi-Slice, Multi-Slice Churn, and V7x Multi-Slice tests
+echo "Deploying Megascale Multi-Slice and V7x Multi-Slice manifests inside namespace $NAMESPACE..."
+kubectl apply -f e2e/manifests/v6e/v6e-16-multi-slice.yaml -n "$NAMESPACE"
+kubectl apply -f e2e/manifests/v7x/v7x-16-multi-slice.yaml -n "$NAMESPACE"
 set +e
-echo "Running Megascale Multi-Slice and Multi-Slice Churn tests..."
-go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice"
-MULTI_SLICE_EXIT=$?
+echo "Running Multi-Slice (Megascale) & Multi-Slice Churn E2E tests (Group 3)..."
+go test -tags=e2e -v ./e2e/webhook/... -run "TestWebhookMutation_V6eMultiSlice|TestWebhookMutation_V6ePodChurnMultiSlice|TestWebhookMutation_V7xMultiSlice"
+GROUP3_EXIT=$?
 set -e
-echo "Cleaning up Megascale Multi-Slice test manifest..."
-kubectl delete -f e2e/manifests/v6e/v6e-16-multi-slice.yaml --ignore-not-found=true || true
-if [ $MULTI_SLICE_EXIT -ne 0 ]; then
-    TEST_EXIT_CODE=$MULTI_SLICE_EXIT
+echo "Cleaning up Multi-Slice manifests..."
+kubectl delete -f e2e/manifests/v6e/v6e-16-multi-slice.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+kubectl delete -f e2e/manifests/v7x/v7x-16-multi-slice.yaml -n "$NAMESPACE" --ignore-not-found=true || true
+if [ $GROUP3_EXIT -ne 0 ]; then
+    TEST_EXIT_CODE=$GROUP3_EXIT
 fi
+
+# Clean up dynamic isolated test namespace
+echo "Deleting isolated test namespace $NAMESPACE..."
+kubectl delete namespace "$NAMESPACE" --ignore-not-found=true || true
 
 # Propagate test exit failure if any
 if [ $TEST_EXIT_CODE -ne 0 ]; then
@@ -110,7 +148,7 @@ if [ $TEST_EXIT_CODE -ne 0 ]; then
 fi
 
 
-# Teardown if requested and script finished successfully
+# Teardown GKE resources if requested and script finished successfully
 if [ "$TEARDOWN_CLUSTER" = true ]; then
     echo "Tearing down cluster $CLUSTER_NAME..."
     gcloud container clusters delete "$CLUSTER_NAME" --zone "$ZONE" --quiet || true


### PR DESCRIPTION
This PR adds support for V7x (Ironwood) TPU architectures to the E2E test suite, introduces validation webhook rejection assertions, and improves test reliability by implementing dynamic namespace isolation and teardown synchronization.

Specific changes:
- Add V7x (Ironwood) TPU E2E test cases covering single-host, multi-host, multi-slice, and multi-container configurations.
- Update all Ray E2E cluster manifests to use official -tpu suffix Docker images (rayproject/ray:nightly-tpu). The image used can be overridden by users through an env var. We use the nightly by default to verify the latest changes in Ray are compatible.
- Implement validation webhook tests to assert API rejection on invalid topologies or host configurations.
- Implement dynamic, isolated test namespace creation/cleanup in `run-e2e.sh` to prevent resource conflicts on TPU nodes.
- Add namespace cleanup waiting loop to avoid TPU hardware locks due to terminating namespaces from previous runs.