### PR TITLE
Fix multi-slice replicaIndex collapse during pod churn

### DIFF
--- a/main.go
+++ b/main.go
@@ -728,10 +728,10 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 			}
 		}
 	}
-	// If no ID was found, this is either the first pod of a new slice in the
-	// cluster. The new slice should either be added to the end (one plus the
-	// last observed slice) or slot into an existing gap (e.g. a previous slice
-	// was preempted).
+	// If no ID was found, this is the first pod of a new slice in the cluster,
+	// which should either be added to the end (one plus the last observed
+	// slice) or slot into an existing gap (e.g. a previous slice was
+	// preempted).
 	if nextLowestId == math.MaxInt32 {
 		// The maximum ID that can be assigned is one past the highest observed.
 		// Range over these possible IDs in order; inclusive of the last.

--- a/main.go
+++ b/main.go
@@ -716,7 +716,7 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 		return 0
 	}
 	nextLowestId := math.MaxInt32
-	existingIndices := make(map[int]bool)
+	existingIndices := make(map[int]bool, len(sliceToTPUHosts))
 	for slice, workerList := range sliceToTPUHosts {
 		if slice.clusterName == clusterName && slice.groupName == groupName && slice.namespace == namespace {
 			existingIndices[slice.replicaIndex] = true
@@ -728,9 +728,15 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 			}
 		}
 	}
-	// first pod of new slice in cluster
+	// If no ID was found, this is either the first pod of a new slice in the
+	// cluster. The new slice should either be added to the end (one plus the
+	// last observed slice) or slot into an existing gap (e.g. a previous slice
+	// was preempted).
 	if nextLowestId == math.MaxInt32 {
-		for i := 0; ; i++ {
+		// The maximum ID that can be assigned is one past the highest observed.
+		// Range over these possible IDs in order; inclusive of the last.
+		maxId := slices.Max(slices.Collect(maps.Keys(existingIndices))) + 1
+		for i := range maxId + 1 {
 			if !existingIndices[i] {
 				nextLowestId = i
 				break

--- a/main.go
+++ b/main.go
@@ -733,10 +733,9 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 	// slice) or slot into an existing gap (e.g. a previous slice was
 	// preempted).
 	if nextLowestId == math.MaxInt32 {
-		// The maximum ID that can be assigned is one past the highest observed.
-		// Range over these possible IDs in order; inclusive of the last.
-		maxId := slices.Max(slices.Collect(maps.Keys(existingIndices))) + 1
-		for i := range maxId + 1 {
+		// By the pigeonhole principle, there must be at least one missing
+		// replica index in the range [0, len(existingIndices)].
+		for i := range len(existingIndices) + 1 {
 			if !existingIndices[i] {
 				nextLowestId = i
 				break

--- a/main.go
+++ b/main.go
@@ -716,10 +716,10 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 		return 0
 	}
 	nextLowestId := math.MaxInt32
-	numReplicas := 0 // tracks # of replicas in worker group created so far
+	existingIndices := make(map[int]bool)
 	for slice, workerList := range sliceToTPUHosts {
 		if slice.clusterName == clusterName && slice.groupName == groupName && slice.namespace == namespace {
-			numReplicas++
+			existingIndices[slice.replicaIndex] = true
 			createdPods := len(workerList)
 			if createdPods < int(slice.numOfHosts) {
 				if slice.replicaIndex < nextLowestId {
@@ -730,7 +730,12 @@ func getReplicaIndex(sliceToTPUHosts map[slice][]int, clusterName string, groupN
 	}
 	// first pod of new slice in cluster
 	if nextLowestId == math.MaxInt32 {
-		nextLowestId = numReplicas
+		for i := 0; ; i++ {
+			if !existingIndices[i] {
+				nextLowestId = i
+				break
+			}
+		}
 	}
 	klog.V(1).InfoS("getReplicaIndex", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "Replica Index", nextLowestId)
 	return nextLowestId

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -476,6 +476,21 @@ func Test_GetReplicaIndex(t *testing.T) {
 			},
 			expectedReplicaIndex: 1,
 		},
+		"multi-slice gap filling - ignore other group": {
+			// should assign Pod to replica 1 if 0 and 2 exist but 1 is missing
+			sliceToTPUHosts: map[slice][]int{
+				slice{"test-cluster", "other-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
+				slice{"test-cluster", "test-group", "test-namespace", 2, int32(4)}:  []int{0, 1, 2, 3},
+			},
+			expectedReplicaIndex: 0,
+		},
+		"multi-slice gap filling - prefer completing slice": {
+			// should assign Pod to replica 1 to complete the slice despite 0 missing
+			sliceToTPUHosts: map[slice][]int{
+				slice{"test-cluster", "test-group", "test-namespace", 1, int32(2)}: []int{0},
+			},
+			expectedReplicaIndex: 1,
+		},
 	}
 
 	// validate getReplicaIndex() returns the expected Replica ID for TPU pods in varying pod slices

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -491,6 +491,12 @@ func Test_GetReplicaIndex(t *testing.T) {
 			},
 			expectedReplicaIndex: 1,
 		},
+		"multi-slice gap filling - no panic on empty with >1 sliceToTPUHosts": {
+			sliceToTPUHosts: map[slice][]int{
+				slice{"test-cluster", "other-group", "test-namespace", 1, int32(2)}: []int{0},
+			},
+			expectedReplicaIndex: 0,
+		},
 	}
 
 	// validate getReplicaIndex() returns the expected Replica ID for TPU pods in varying pod slices

--- a/webhook_main_test.go
+++ b/webhook_main_test.go
@@ -453,13 +453,28 @@ func Test_GetReplicaIndex(t *testing.T) {
 			expectedReplicaIndex: 1,
 		},
 		"multi-slice worker group": {
-			// should assign Pod to replica 4 since 3 existing slices with all workers created
+			// should assign Pod to replica 3 since 3 existing slices with all workers created
 			sliceToTPUHosts: map[slice][]int{
 				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2, 3},
 				slice{"test-cluster", "test-group", "test-namespace", 2, int32(4)}: []int{0, 1, 2, 3},
 			},
 			expectedReplicaIndex: 3,
+		},
+		"multi-slice gap filling - lower index missing": {
+			// should assign Pod to replica 0 even if replica 1 exists, if 0 is missing
+			sliceToTPUHosts: map[slice][]int{
+				slice{"test-cluster", "test-group", "test-namespace", 1, int32(4)}: []int{0, 1, 2, 3},
+			},
+			expectedReplicaIndex: 0,
+		},
+		"multi-slice gap filling - middle index missing": {
+			// should assign Pod to replica 1 if 0 and 2 exist but 1 is missing
+			sliceToTPUHosts: map[slice][]int{
+				slice{"test-cluster", "test-group", "test-namespace", 0, int32(4)}: []int{0, 1, 2, 3},
+				slice{"test-cluster", "test-group", "test-namespace", 2, int32(4)}: []int{0, 1, 2, 3},
+			},
+			expectedReplicaIndex: 1,
 		},
 	}
 


### PR DESCRIPTION
This fix addresses a bug during rolling nodepool upgrades, where slices were partially deleted and pods would over-subscribe to other slices.

getReplicaIndex would incorrectly calculate the next replica index using the count of existing replicas in the cache. If a lower-indexed replica was completely deleted (e.g., Slice 0 gone but Slice 1 remains), the count would be 1, causing new pods to be assigned to Slice 1 instead of filling the gap at Index 0.

The new logic finds the lowest unused replica index by tracking existing indices in a map.

Only affects the legacy (no multi host index) path.